### PR TITLE
fix broken links and add notice

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,7 @@
 <section class="whitebackground">
 
+<p><strong>Please note: this website is under-construction. Please visit https://zowe.org and check the most recent news of Zowe.</strong></p>
+
 <h1 id="what-is-zowe">WHAT IS ZOWE?</h1>
 
 <p>
@@ -23,8 +25,8 @@ Zowe consists of the following main components.
 <p>
 The easiest way to get started with Zowe is by downloading the convenience build. You can also go to the GitHub repository to build Zowe on your own.
 </p>
-<button><a href="https://docs.zowe.org">Zowe z/OS Components</a></button>
-<button><a href="https://docs.zowe.org">Zowe Command Line Interface</a></button>
+<button><a href="https://zowe.github.io/docs-site/">Zowe z/OS Components</a></button>
+<button><a href="https://zowe.github.io/docs-site/">Zowe Command Line Interface</a></button>
 <button><a href="https://github.com/zowe">Zowe Github repository</a></button>
 <p>
 * Please note the Zowe binaries are made available to you by Zowe Binary Projects a Series of LF Projects, LLC, and not by The Linux Foundation or the Open Mainframe Project.
@@ -37,7 +39,7 @@ The easiest way to get started with Zowe is by downloading the convenience build
 <p>
 There are hundreds of developers – called Committers – who are dedicated to extending Zowe and building a community around open source on the mainframe. Discover how you can contribute code, ideas, generate issues and earn your Committer status.
 </p>
-<button><a href="https://docs.zowe.org">READ THE DOCS</a></button>
+<button><a href="https://zowe.github.io/docs-site/">READ THE DOCS</a></button>
 
 </section>
 


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

Related to https://github.com/zowe/docs-site/issues/586, fix broken links and add a under-construction notice until this website is ready.