### PR TITLE
Change CNAME to www.zowe.org to fix cert errors

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-zowe.org
+www.zowe.org


### PR DESCRIPTION
Signed-off-by: John Mertic <jmertic@linuxfoundation.org>