### PR TITLE
use original zowe tracking id

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,13 +5,13 @@
 <html lang="en-US" class="no-js no-svg">
 <head>
 <!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-82811140-33"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-123892882-1"></script>
 <script async src="https://cdn.jsdelivr.net/npm/details-polyfill@1/index.min.js"></script>
 <script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());
- gtag('config', 'UA-82811140-33');
+ gtag('config', 'UA-123892882-1');
 </script>
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="shortcut icon" href="assets/favicon.ico" />


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>

@Tbr00ksy this is the old tracking id we were using and what is still used on docs website.

@jmertic We also need to update the legal/post download pages hosted on S3 to use the same tracking id. It helped us to track conversions, like from what point and percentage of users clicked download buttons.

Thanks!