### PR TITLE
Add slack, forum, and twitter buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ docs_site_url: https://docs.zowe.org
 community_site_url: https://github.com/zowe/community/blob/master/README.md
 forums_url: https://community.openmainframeproject.org/c/zowe
 slack_url: https://slack.openmainframeproject.org
+twitter_url: https://twitter.com/openmfproject?lang=en
 mailing_list_user_url: https://lists.openmainframeproject.org/g/zowe-user
 youtube_zowe_url: https://www.youtube.com/playlist?list=PL8REpLGaY9QE_9d57tw3KQdwSVLKuTpUZ
 conformance_page_url: https://www.openmainframeproject.org/projects/zowe/conformance

--- a/index.md
+++ b/index.md
@@ -121,6 +121,9 @@ Check out quick start guides, user guides, developer guides, references, tutoria
 <p>
 Zowe is more than a framework - it's a worldwide community of developers, vendors, and users building and extending Zowe. Discover how you can connect, learn, and contribute to its future.
 </p>
+<button><a href="{{ site.slack_url }}">Slack channels</a></button>
+<button><a href="{{ site.forums_url }}">FAQ forum</a></button>
+<button><a href="{{ site.twitter_url }}">Twitter</a></button>
 <button><a href="{{ site.community_site_url }}">Learn more</a></button>
 
 </section>


### PR DESCRIPTION
Add links to sites including Slack, Twitter, and OMP Forum. Addresses zowe/docs-site#863 

Preview: 
![image](https://user-images.githubusercontent.com/36675406/70555267-ba94cd80-1b4c-11ea-9b68-d58aba723ca0.png)
