### PR TITLE
Add slack, twitter, and forum buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ docs_site_url: https://docs.zowe.org
 community_site_url: https://github.com/zowe/community/blob/master/README.md
 forums_url: https://community.openmainframeproject.org/c/zowe
 slack_url: https://slack.openmainframeproject.org
+twitter_url: https://twitter.com/openmfproject?lang=en
 mailing_list_user_url: https://lists.openmainframeproject.org/g/zowe-user
 youtube_zowe_url: https://www.youtube.com/playlist?list=PL8REpLGaY9QE_9d57tw3KQdwSVLKuTpUZ
 conformance_page_url: https://www.openmainframeproject.org/projects/zowe/conformance

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -201,6 +201,12 @@ float:left;
 
 }
 
+.bluebackground button p{
+  color:white !important;
+  font-size: .5em;
+  text-decoration:none !important;
+ }
+
 .twoboxes {
  background-color:#145391;
  padding-left:5%;
@@ -295,7 +301,7 @@ footer {
     color: #33332B;
     padding: 5px;
 }
- 
+
 summary {
   display:list-item;
   cursor:pointer;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -180,10 +180,9 @@ float:left;
  text-decoration:none;
 }
 
-
-
 .bluebackground button {
  padding:2%;
+ padding-bottom: 1%;
  font-family:"Roboto Condensed", sans-serif;
  margin-top:2%;
  margin-right:3%;
@@ -203,8 +202,9 @@ float:left;
 
 .bluebackground button p{
   color:white !important;
-  font-size: .5em;
-  text-decoration:none !important;
+  font-size: .7em;
+  font-weight: 350;
+
  }
 
 .twoboxes {

--- a/index.md
+++ b/index.md
@@ -121,7 +121,7 @@ Check out quick start guides, user guides, developer guides, references, tutoria
 <p>
 Zowe is more than a framework - it's a worldwide community of developers, vendors, and users building and extending Zowe. Discover how you can connect, learn, and contribute to its future.
 </p>
-<button><a href="{{ site.slack_url }}">Slack channels <p>Ask questions, report problems, and more.</p></a></button>
+<button><a href="{{ site.slack_url }}">Slack channels <p>Ask questions, report problems, and interact with the community.</p></a></button>
 <button><a href="{{ site.forums_url }}">FAQ forum <p>Read and discuss frequently-asked questions about Zowe.</p></a></button>
 <button><a href="{{ site.twitter_url }}">Twitter <p>Follow the Open Mainframe Project on Twitter.</p></a></button>
 <button><a href="{{ site.community_site_url }}">Learn more <p>Find more community resources.</p></a></button>

--- a/index.md
+++ b/index.md
@@ -121,10 +121,10 @@ Check out quick start guides, user guides, developer guides, references, tutoria
 <p>
 Zowe is more than a framework - it's a worldwide community of developers, vendors, and users building and extending Zowe. Discover how you can connect, learn, and contribute to its future.
 </p>
-<button><a href="{{ site.slack_url }}">Slack channels</a></button>
-<button><a href="{{ site.forums_url }}">FAQ forum</a></button>
-<button><a href="{{ site.twitter_url }}">Twitter</a></button>
-<button><a href="{{ site.community_site_url }}">Learn more</a></button>
+<button><a href="{{ site.slack_url }}">Slack channels <p>Ask questions, report problems, and more.</p></a></button>
+<button><a href="{{ site.forums_url }}">FAQ forum <p>Read and discuss frequently-asked questions about Zowe.</p></a></button>
+<button><a href="{{ site.twitter_url }}">Twitter <p>Follow the Open Mainframe Project on Twitter.</p></a></button>
+<button><a href="{{ site.community_site_url }}">Learn more <p>Find more community resources.</p></a></button>
 
 </section>
 

--- a/index.md
+++ b/index.md
@@ -121,6 +121,9 @@ Check out quick start guides, user guides, developer guides, references, tutoria
 <p>
 Zowe is more than a framework - it's a worldwide community of developers, vendors, and users building and extending Zowe. Discover how you can connect, learn, and contribute to its future.
 </p>
+<button><a href="{{ site.slack_url }}">Slack channels</a></button>
+<button><a href="{{ site.forums_url }}">FAQ forum</a></button>
+<button><a href="{{ site.twitter_url }}">Twitter</a></button>
 <button><a href="{{ site.community_site_url }}">Learn more</a></button>
 
 </section>


### PR DESCRIPTION
Add links to sites including Slack, Twitter, and OMP Forum. Addresses zowe/docs-site#863 

**Preview:** 
![image](https://user-images.githubusercontent.com/36675406/70558049-1e6dc500-1b52-11ea-8a36-383f6cc0e388.png)


Signed-off-by: BrandonJenkins14 <36675406+BrandonJenkins14@users.noreply.github.com>