### PR TITLE
Add Zowe CLI 1.8.1

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -2,6 +2,8 @@
 # Note - keep this in order as the latest release is pulled from the first item in the list!
 
 - version: 1.8.0
+  zos_version: 1.8.0
+  cli_version: 1.8.1
   release_date: 2020-02-07
   documentation: stable
 - version: 1.7.1

--- a/index.md
+++ b/index.md
@@ -55,8 +55,13 @@ Zowe offers modern interfaces to interact with z/OS and allows you to work with 
 <p>
 The easiest way to get started with Zowe is by downloading the convenience build. You can also go to the GitHub repository to build Zowe on your own.
 </p>
+{% if site.data.releases[0].cli_version and site.data.releases[0].zos_version %}
+<a class="button" href="{{ site.zos_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].zos_version }} z/OS Components</a>
+<a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].cli_version }} CLI</a>
+{% else %}
 <a class="button" href="{{ site.zos_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].version }} z/OS Components</a>
 <a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].version }} CLI</a>
+{% endif %}
 <a class="button" href="{{ site.github_repo_url }}">Zowe GitHub repositories</a>
 <details>
 <summary><b>Past Releases</b></summary>

--- a/index.md
+++ b/index.md
@@ -56,8 +56,8 @@ Zowe offers modern interfaces to interact with z/OS and allows you to work with 
 The easiest way to get started with Zowe is by downloading the convenience build. You can also go to the GitHub repository to build Zowe on your own.
 </p>
 {% if site.data.releases[0].cli_version and site.data.releases[0].zos_version %}
-<a class="button" href="{{ site.zos_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].zos_version }} z/OS Components</a>
-<a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].cli_version }} CLI</a>
+<a class="button" href="{{ site.zos_download_url }}{{ site.data.releases[0].zos_version }}">Zowe {{ site.data.releases[0].zos_version }} z/OS Components</a>
+<a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].cli_version }}">Zowe {{ site.data.releases[0].cli_version }} CLI</a>
 {% else %}
 <a class="button" href="{{ site.zos_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].version }} z/OS Components</a>
 <a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].version }} CLI</a>


### PR DESCRIPTION
Added optional "zos_version" and "cli_version" fields to releases.yaml . 

This lets us separate z/OS and CLI component releases on zowe.org. A full review of version presentation in light of split versioning would be good in the future.