### PR TITLE
1.9.0, support split cli

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,7 @@ youtube_zowe_url: https://www.youtube.com/playlist?list=PL8REpLGaY9QE_9d57tw3KQd
 conformance_page_url: https://www.openmainframeproject.org/projects/zowe/conformance
 zos_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?version=
 cli_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli&version=
+cli_plugins_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli-plugins&version=
 cli_active_development_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli-active-development&version=
 smpe_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=smpe&version=
 nightly_build_url: https://zowe.jfrog.io/zowe/webapp/#/artifacts/browse/tree/General/libs-release-local/org/zowe/nightly

--- a/_data/announcements.yml
+++ b/_data/announcements.yml
@@ -1,5 +1,4 @@
 # Announcements
-- announcement: "A pre-release of the Zowe SMP/E install is now available. This is an alpha release based on Zowe 1.8.0, and should not be used in production."
-  link: "https://docs.zowe.org/stable/getting-started/summaryofchanges.html#zowe-smp-e-alpha-august-2019"
+- announcement: "The first release of the Zowe SMP/E FMID is now available. This is a release based on Zowe 1.9.0."
 - announcement: "An active development, offline-installable version of the Zowe CLI is now available. This is the @zowe/cli@latest release also available on public NPM."
   link: "https://docs.zowe.org/active-development/getting-started/summaryofchanges.html#what-is-active-development"

--- a/_data/announcements.yml
+++ b/_data/announcements.yml
@@ -1,4 +1,4 @@
 # Announcements
-- announcement: "The first release of the Zowe SMP/E build is now available, with FMID of AZWE001. This is the same content as the Zowe 1.9.0 convenience build!."
+- announcement: "The first release of the Zowe SMP/E build is now available, with FMID of AZWE001. This is the same content as the Zowe 1.9.0 convenience build."
 - announcement: "An active development, offline-installable version of the Zowe CLI is now available. This is the @zowe/cli@latest release also available on public NPM."
   link: "https://docs.zowe.org/active-development/getting-started/summaryofchanges.html#what-is-active-development"

--- a/_data/announcements.yml
+++ b/_data/announcements.yml
@@ -1,4 +1,4 @@
 # Announcements
-- announcement: "The first release of the Zowe SMP/E FMID is now available. This is a release based on Zowe 1.9.0."
+- announcement: "The first release of the Zowe SMP/E build is now available, with FMID of AZWE001. This is the same content as the Zowe 1.9.0 convenience build!."
 - announcement: "An active development, offline-installable version of the Zowe CLI is now available. This is the @zowe/cli@latest release also available on public NPM."
   link: "https://docs.zowe.org/active-development/getting-started/summaryofchanges.html#what-is-active-development"

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,11 +1,17 @@
 # List of Zowe releases - update here and it will update the entire site :-)
 # Note - keep this in order as the latest release is pulled from the first item in the list!
 
+- version: 1.9.0
+  zos_version: 1.9.0
+  cli_version: 1.9.0
+  cli_plugins_version: 1.9.0
+  release_date: 2020-02-28
+  documentation: stable
 - version: 1.8.0
   zos_version: 1.8.0
   cli_version: 1.8.1
   release_date: 2020-02-07
-  documentation: stable
+  documentation: v-1-8-x
 - version: 1.7.1
   release_date: 2019-12-04
   documentation: v-1-7-x

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -3,6 +3,8 @@
 
 - version: 1.9.0
   zos_version: 1.9.0
+  smpe_version: 1.9.0
+  smpe_sysmod: FMID
   cli_version: 1.9.0
   cli_plugins_version: 1.9.0
   release_date: 2020-02-28

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -173,6 +173,7 @@ float:left;
  border:3px solid #145391;
  color:#145391;
  line-height: 5em;
+ white-space: nowrap;
 }
 
 .whitebackground a.button {
@@ -195,6 +196,7 @@ float:left;
  border:3px solid white;
  color:white;
  line-height: 7em;
+ white-space: nowrap;
 }
 .bluebackground a.button {
  color:white !important;

--- a/index.md
+++ b/index.md
@@ -55,9 +55,10 @@ Zowe offers modern interfaces to interact with z/OS and allows you to work with 
 <p>
 The easiest way to get started with Zowe is by downloading the convenience build. You can also go to the GitHub repository to build Zowe on your own.
 </p>
-{% if site.data.releases[0].cli_version and site.data.releases[0].zos_version %}
+{% if site.data.releases[0].cli_version and site.data.releases[0].cli_plugins_version and site.data.releases[0].zos_version %}
 <a class="button" href="{{ site.zos_download_url }}{{ site.data.releases[0].zos_version }}">Zowe {{ site.data.releases[0].zos_version }} z/OS Components</a>
-<a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].cli_version }}">Zowe {{ site.data.releases[0].cli_version }} CLI</a>
+<a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].cli_version }}">Zowe {{ site.data.releases[0].cli_version }} CLI Core</a>
+<a class="button" href="{{ site.cli_plugins_download_url }}{{ site.data.releases[0].cli_plugins_version }}">Zowe {{ site.data.releases[0].cli_plugins_version }} CLI Plugins</a>
 {% else %}
 <a class="button" href="{{ site.zos_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].version }} z/OS Components</a>
 <a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].version }}">Zowe {{ site.data.releases[0].version }} CLI</a>
@@ -70,13 +71,28 @@ The easiest way to get started with Zowe is by downloading the convenience build
   <table>
   {% endif %}
   {% unless forloop.first %}
-  <tr>
-    <td>Zowe {{release.version}} ({{release.release_date}})</td>
-    <td><a href="{{site.zos_download_url}}{{release.version}}">Zowe z/OS Components</a></td>
-    <td><a href="{{site.cli_download_url}}{{release.version}}">Zowe Command Line Interface</a></td>
-    <td><a href="{{ site.docs_site_url }}/{{release.documentation}}/getting-started/summaryofchanges.html">Release Notes</a></td>
-    <td><a href="{{ site.docs_site_url }}/{{release.documentation}}">Documentation</a></td>
-  </tr>
+    {% if release.cli_version and release.zos_version %}
+    <tr>
+      <td>Zowe {{release.version}} ({{release.release_date}})</td>
+      <td><a href="{{site.zos_download_url}}{{release.zos_version}}">Zowe z/OS Components</a></td>
+        {% if release.cli_plugins_version %}
+        <td><a href="{{site.cli_download_url}}{{release.cli_version}}">Zowe Command Line Interface Core</a></td>
+        <td><a href="{{site.cli_download_url}}{{release.cli_plugins_version}}">Zowe Command Line Interface Plugins</a></td>
+        {% else %}
+        <td><a href="{{site.cli_download_url}}{{release.cli_version}}">Zowe Command Line Interface</a></td>
+        {% endif %}
+      <td><a href="{{ site.docs_site_url }}/{{release.documentation}}/getting-started/summaryofchanges.html">Release Notes</a></td>
+      <td><a href="{{ site.docs_site_url }}/{{release.documentation}}">Documentation</a></td>
+    </tr>
+    {% else %}
+    <tr>
+      <td>Zowe {{release.version}} ({{release.release_date}})</td>
+      <td><a href="{{site.zos_download_url}}{{release.version}}">Zowe z/OS Components</a></td>
+      <td><a href="{{site.cli_download_url}}{{release.version}}">Zowe Command Line Interface</a></td>
+      <td><a href="{{ site.docs_site_url }}/{{release.documentation}}/getting-started/summaryofchanges.html">Release Notes</a></td>
+      <td><a href="{{ site.docs_site_url }}/{{release.documentation}}">Documentation</a></td>
+    </tr>
+    {% endif %}
   {% endunless %}
   {% if forloop.last %}
   </table>

--- a/index.md
+++ b/index.md
@@ -94,7 +94,7 @@ The easiest way to get started with Zowe is by downloading the convenience build
       {% endif %}
     {% endif %}
     {% if release.cli_plugins_version %}
-      <td><a href="{{site.cli_download_url}}{{release.cli_plugins_version}}">Zowe Command Line Interface Plugins</a></td>
+      <td><a href="{{site.cli_plugins_download_url}}{{release.cli_plugins_version}}">Zowe Command Line Interface Plugins</a></td>
     {% else %}
       <td></td>
     {% endif %}

--- a/index.md
+++ b/index.md
@@ -55,8 +55,9 @@ Zowe offers modern interfaces to interact with z/OS and allows you to work with 
 <p>
 The easiest way to get started with Zowe is by downloading the convenience build. You can also go to the GitHub repository to build Zowe on your own.
 </p>
-{% if site.data.releases[0].cli_version and site.data.releases[0].cli_plugins_version and site.data.releases[0].zos_version %}
+{% if site.data.releases[0].cli_version and site.data.releases[0].cli_plugins_version and site.data.releases[0].zos_version and site.data.releases[0].smpe_version %}
 <a class="button" href="{{ site.zos_download_url }}{{ site.data.releases[0].zos_version }}">Zowe {{ site.data.releases[0].zos_version }} z/OS Components</a>
+<a class="button" href="{{ site.smpe_download_url }}{{ site.data.releases[0].smpe_version }}">Zowe {{ site.data.releases[0].smpe_version }} SMP/E {{ site.data.releases[0].smpe_sysmod }}</a>
 <a class="button" href="{{ site.cli_download_url }}{{ site.data.releases[0].cli_version }}">Zowe {{ site.data.releases[0].cli_version }} CLI Core</a>
 <a class="button" href="{{ site.cli_plugins_download_url }}{{ site.data.releases[0].cli_plugins_version }}">Zowe {{ site.data.releases[0].cli_plugins_version }} CLI Plugins</a>
 {% else %}
@@ -71,21 +72,31 @@ The easiest way to get started with Zowe is by downloading the convenience build
   <table>
   {% endif %}
   {% unless forloop.first %}
-    {% if release.cli_version and release.zos_version %}
     <tr>
       <td>Zowe {{release.version}} ({{release.release_date}})</td>
+    {% if release.zos_version %}
       <td><a href="{{site.zos_download_url}}{{release.zos_version}}">Zowe z/OS Components</a></td>
-        {% if release.cli_plugins_version %}
-        <td><a href="{{site.cli_download_url}}{{release.cli_version}}">Zowe Command Line Interface Core</a></td>
-        <td><a href="{{site.cli_download_url}}{{release.cli_plugins_version}}">Zowe Command Line Interface Plugins</a></td>
-        {% else %}
-        <td><a href="{{site.cli_download_url}}{{release.cli_version}}">Zowe Command Line Interface</a></td>
-        {% endif %}
     {% else %}
-    <tr>
-      <td>Zowe {{release.version}} ({{release.release_date}})</td>
       <td><a href="{{site.zos_download_url}}{{release.version}}">Zowe z/OS Components</a></td>
-      <td><a href="{{site.cli_download_url}}{{release.version}}">Zowe Command Line Interface</a></td>
+    {% endif %}
+    {% if release.smpe_version and release.smpe_sysmod %}
+      <td><a href="{{site.smpe_download_url}}{{release.smpe_version}}">Zowe SMP/E {{release.smpe_sysmod}}</a></td>
+    {% else %}
+      <td></td>
+    {% endif %}
+    {% if release.cli_version and release.cli_plugins_version %}
+      <td><a href="{{site.cli_download_url}}{{release.cli_version}}">Zowe Command Line Interface Core</a></td>
+    {% else %}
+      {% if release.cli_version %}
+        <td><a href="{{site.cli_download_url}}{{release.cli_version}}">Zowe Command Line Interface</a></td>
+      {% else %}
+        <td><a href="{{site.cli_download_url}}{{release.version}}">Zowe Command Line Interface</a></td>
+      {% endif %}
+    {% endif %}
+    {% if release.cli_plugins_version %}
+      <td><a href="{{site.cli_download_url}}{{release.cli_plugins_version}}">Zowe Command Line Interface Plugins</a></td>
+    {% else %}
+      <td></td>
     {% endif %}
       <td><a href="{{ site.docs_site_url }}/{{release.documentation}}/getting-started/summaryofchanges.html">Release Notes</a></td>
       <td><a href="{{ site.docs_site_url }}/{{release.documentation}}">Documentation</a></td>
@@ -108,15 +119,12 @@ The easiest way to get started with Zowe is by downloading the convenience build
   </ul>
 </p>
 </details>
-{% if site.smpe_download_url or site.cli_latest_download_url %}
+{% if site.cli_active_development_download_url %}
 <details>
 <summary><b>Pre-Release Builds</b></summary>
 <p>
 If you want to try newer, actively-developed Zowe features and functions, download the following packages:
 </p>
-{% if site.smpe_download_url %}
-<a class="button" href="{{ site.smpe_download_url }}{{ site.data.releases[0].version }}alpha1">Zowe {{ site.data.releases[0].version }} SMP/E Alpha</a>
-{% endif %}
 {% if site.cli_active_development_download_url %}
 <a class="button" href="{{ site.cli_active_development_download_url }}{{ site.data.active_development.cli.version }}&package={{ site.data.active_development.cli.package }}">Zowe CLI (Active Development)</a>
 {% endif %}

--- a/index.md
+++ b/index.md
@@ -81,18 +81,15 @@ The easiest way to get started with Zowe is by downloading the convenience build
         {% else %}
         <td><a href="{{site.cli_download_url}}{{release.cli_version}}">Zowe Command Line Interface</a></td>
         {% endif %}
-      <td><a href="{{ site.docs_site_url }}/{{release.documentation}}/getting-started/summaryofchanges.html">Release Notes</a></td>
-      <td><a href="{{ site.docs_site_url }}/{{release.documentation}}">Documentation</a></td>
-    </tr>
     {% else %}
     <tr>
       <td>Zowe {{release.version}} ({{release.release_date}})</td>
       <td><a href="{{site.zos_download_url}}{{release.version}}">Zowe z/OS Components</a></td>
       <td><a href="{{site.cli_download_url}}{{release.version}}">Zowe Command Line Interface</a></td>
+    {% endif %}
       <td><a href="{{ site.docs_site_url }}/{{release.documentation}}/getting-started/summaryofchanges.html">Release Notes</a></td>
       <td><a href="{{ site.docs_site_url }}/{{release.documentation}}">Documentation</a></td>
     </tr>
-    {% endif %}
   {% endunless %}
   {% if forloop.last %}
   </table>


### PR DESCRIPTION
Signed-off-by: MarkAckert <mark.ackert@broadcom.com>

Supports the new split CLI package. Past releases listings come in 3 formats:
- "Single release" - zos and cli versions are the same (1.0.0-1.8.0)
- "z/OS and CLI Version Separation" - zos and cli versions are different (1.8.1)
- "z/OS and CLI Version Separation, CLI Archive Split" - 1.9.0

