### PR TITLE
Remove Active Development CLI Download

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,7 @@ conformance_page_url: https://www.openmainframeproject.org/projects/zowe/conform
 zos_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?version=
 cli_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli&version=
 cli_plugins_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli-plugins&version=
+cli_active_development_download_url:
 smpe_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=smpe&version=
 nightly_build_url: https://zowe.jfrog.io/zowe/webapp/#/artifacts/browse/tree/General/libs-release-local/org/zowe/nightly
 zowe_build_slack_url: https://openmainframeproject.slack.com/archives/CC9QW5NJE

--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,6 @@ conformance_page_url: https://www.openmainframeproject.org/projects/zowe/conform
 zos_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?version=
 cli_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli&version=
 cli_plugins_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli-plugins&version=
-cli_active_development_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli-active-development&version=
 smpe_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=smpe&version=
 nightly_build_url: https://zowe.jfrog.io/zowe/webapp/#/artifacts/browse/tree/General/libs-release-local/org/zowe/nightly
 zowe_build_slack_url: https://openmainframeproject.slack.com/archives/CC9QW5NJE

--- a/_data/announcements.yml
+++ b/_data/announcements.yml
@@ -1,4 +1,2 @@
 # Announcements
 - announcement: "The first release of the Zowe SMP/E build is now available, with FMID of AZWE001. This is the same content as the Zowe 1.9.0 convenience build."
-- announcement: "An active development, offline-installable version of the Zowe CLI is now available. This is the @zowe/cli@latest release also available on public NPM."
-  link: "https://docs.zowe.org/active-development/getting-started/summaryofchanges.html#what-is-active-development"

--- a/index.md
+++ b/index.md
@@ -72,6 +72,9 @@ The easiest way to get started with Zowe is by downloading the convenience build
   </p>
 {% endif %}
 <p><a class="button" href="{{ site.github_repo_url }}">Zowe GitHub repositories</a></p>
+<p><i>
+* Please note the Zowe binaries are made available to you by Zowe Binary Projects a Series of LF Projects, LLC, and not by The Linux Foundation or the Open Mainframe Project.
+</i></p>
 <details>
 <summary><b>Past Releases</b></summary>
 {% for release in site.data.releases %}
@@ -126,27 +129,14 @@ The easiest way to get started with Zowe is by downloading the convenience build
   </ul>
 </p>
 </details>
-{% if site.cli_active_development_download_url %}
+
 <details>
 <summary><b>Pre-Release Builds</b></summary>
-<p>
-If you want to try newer, actively-developed Zowe features and functions, download the following packages:
-</p>
-{% if site.cli_active_development_download_url %}
-<a class="button" href="{{ site.cli_active_development_download_url }}{{ site.data.active_development.cli.version }}&package={{ site.data.active_development.cli.package }}">Zowe CLI (Active Development)</a>
-{% endif %}
-</details>
-{% endif %}
-<p><i>
-* Please note the Zowe binaries are made available to you by Zowe Binary Projects a Series of LF Projects, LLC, and not by The Linux Foundation or the Open Mainframe Project.
-</i></p>
-
 <p>
 If you don't have infrastructure to install Zowe locally, you can use the Zowe Trial hosted by IBM. This no-charge trial is available in two hours for three days.
 </p>
 <a class="button" href="{{ site.ibm_ztrial_url }}">Request a trial</a>
 <p><i>* By proceeding to the trial, you will be leaving the Zowe.org website.</i></p>
-
 </section>
 
 <section class="whitebackground">

--- a/index.md
+++ b/index.md
@@ -127,7 +127,17 @@ The easiest way to get started with Zowe is by downloading the convenience build
   </ul>
 </p>
 </details>
-
+{% if site.cli_active_development_download_url %}
+<details>
+<summary><b>Pre-Release Builds</b></summary>
+<p>
+If you want to try newer, actively-developed Zowe features and functions, download the following packages:
+</p>
+{% if site.cli_active_development_download_url %}
+<a class="button" href="{{ site.cli_active_development_download_url }}{{ site.data.active_development.cli.version }}&package={{ site.data.active_development.cli.package }}">Zowe CLI (Active Development)</a>
+{% endif %}
+</details>
+{% endif %}
 <p><i>
 * Please note the Zowe binaries are made available to you by Zowe Binary Projects a Series of LF Projects, LLC, and not by The Linux Foundation or the Open Mainframe Project.
 </i></p>

--- a/index.md
+++ b/index.md
@@ -72,9 +72,7 @@ The easiest way to get started with Zowe is by downloading the convenience build
   </p>
 {% endif %}
 <p><a class="button" href="{{ site.github_repo_url }}">Zowe GitHub repositories</a></p>
-<p><i>
-* Please note the Zowe binaries are made available to you by Zowe Binary Projects a Series of LF Projects, LLC, and not by The Linux Foundation or the Open Mainframe Project.
-</i></p>
+
 <details>
 <summary><b>Past Releases</b></summary>
 {% for release in site.data.releases %}
@@ -130,13 +128,15 @@ The easiest way to get started with Zowe is by downloading the convenience build
 </p>
 </details>
 
-<details>
-<summary><b>Pre-Release Builds</b></summary>
+<p><i>
+* Please note the Zowe binaries are made available to you by Zowe Binary Projects a Series of LF Projects, LLC, and not by The Linux Foundation or the Open Mainframe Project.
+</i></p>
 <p>
 If you don't have infrastructure to install Zowe locally, you can use the Zowe Trial hosted by IBM. This no-charge trial is available in two hours for three days.
 </p>
 <a class="button" href="{{ site.ibm_ztrial_url }}">Request a trial</a>
-<p><i>* By proceeding to the trial, you will be leaving the Zowe.org website.</i></p>
+<p><i>* By proceeding to the trial, you will leave the Zowe.org website.</i></p>
+
 </section>
 
 <section class="whitebackground">


### PR DESCRIPTION
Active Development CLI package on Zowe.org is outdated and should be removed. We can reintroduce download buttons when more forward features are added to @latest CLI or another Zowe component.

zowe/docs-site#1140 is open to temporarily remove the Active Development documentation. 

@MarkAckert or ZLC, can you ensure that the changes here don't disrupt anything besides the CLI download? I moved the disclaimer statement about Zowe Binaries up near the primary download buttons. 