### PR TITLE
zowe v1.12.0 is ready

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # Copyright Contributors to the Zowe project.
 title: Zowe
 description: > # this means to ignore newlines until "keywords:"
-  Zowe is an open source framework for leveraging data and applications in z/OS from modern applications and tools.
+  Zowe is an open source framework for leveraging data and applications in z/OS from modern applications and tools
 keywords: mainframe, zos, open source, framework
 theme: jekyll-theme-cayman
 auto_ids: true

--- a/_config.yml
+++ b/_config.yml
@@ -18,11 +18,11 @@ slack_url: https://slack.openmainframeproject.org
 mailing_list_user_url: https://lists.openmainframeproject.org/g/zowe-user
 youtube_zowe_url: https://www.youtube.com/playlist?list=PL8REpLGaY9QE_9d57tw3KQdwSVLKuTpUZ
 conformance_page_url: https://www.openmainframeproject.org/projects/zowe/conformance
-zos_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?version=
-cli_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli&version=
-cli_plugins_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli-plugins&version=
-cli_active_development_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=cli-active-development&version=
-smpe_download_url: https://d1xozlojgf8voe.cloudfront.net/legal.html?type=smpe&version=
+zos_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/download/legal.html?version=
+cli_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/download/legal.html?type=cli&version=
+cli_plugins_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/download/legal.html?type=cli-plugins&version=
+cli_active_development_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/download/legal.html?type=cli-active-development&version=
+smpe_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/download/legal.html?type=smpe&version=
 nightly_build_url: https://zowe.jfrog.io/zowe/webapp/#/artifacts/browse/tree/General/libs-release-local/org/zowe/nightly
 zowe_build_slack_url: https://openmainframeproject.slack.com/archives/CC9QW5NJE
 lts_url: https://github.com/zowe/zlc/blob/master/process/ReleaseProcess.md 

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,6 +1,15 @@
 # List of Zowe releases - update here and it will update the entire site :-)
 # Note - keep this in order as the latest release is pulled from the first item in the list!
 
+- version: 1.12.0
+  zos_version: 1.12.0
+  smpe_version: 1.12.0
+  smpe_sysmod: PTF
+  smpe_numbers: UO01945 and UO01946
+  cli_version: 1.12.0
+  cli_plugins_version: 1.12.0
+  release_date: 2020-06-12
+  documentation: stable
 - version: 1.11.0
   zos_version: 1.11.0
   smpe_version: 1.11.0
@@ -9,7 +18,7 @@
   cli_version: 1.11.0
   cli_plugins_version: 1.11.0
   release_date: 2020-05-01
-  documentation: stable
+  documentation: v1-11-x
 - version: 1.10.0
   zos_version: 1.10.0
   smpe_version: 1.10.0


### PR DESCRIPTION
Signed-off-by: Jack (T.) Jia <jack-tiefeng.jia@ibm.com>