### PR TITLE
Add Zowe SDK information and buttons

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,16 +23,19 @@ cli_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/do
 cli_plugins_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/download/legal.html?type=cli-plugins&version=
 cli_active_development_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/download/legal.html?type=cli-active-development&version=
 smpe_download_url: https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/download/legal.html?type=smpe&version=
+zowe_node_sdk_download_url:
+zowe_python_sdk_download_url:
 nightly_build_url: https://zowe.jfrog.io/zowe/webapp/#/artifacts/browse/tree/General/libs-release-local/org/zowe/nightly
 zowe_build_slack_url: https://openmainframeproject.slack.com/archives/CC9QW5NJE
-lts_url: https://github.com/zowe/zlc/blob/master/process/ReleaseProcess.md 
+lts_url: https://github.com/zowe/zlc/blob/master/process/ReleaseProcess.md
 zowe_fmid: AZWE001
 zowe_fmid_oss_version: 1.9.0
 zos_component_install_doc_url: https://docs.zowe.org/stable/user-guide/install-zos.html
 zowe_cli_install_doc_url: https://docs.zowe.org/stable/user-guide/cli-installcli.html
 zowe_explorer_install_doc_url: https://docs.zowe.org/stable/user-guide/ze-install.html
+zowe_sdk_install_doc_url: https://docs.zowe.org/stable/user-guide/
 vscode_marketplace_url: https://marketplace.visualstudio.com/items?itemName=Zowe.vscode-extension-for-zowe
-
+#TODO add url for zowe_sdk_install_doc_url, zowe_node_sdk_download_url, and zowe_python_sdk_download_url
 
 gems:
 # Redirect plugin

--- a/download.md
+++ b/download.md
@@ -20,7 +20,7 @@
 <div class="card-deck">
 <div class="card bg-light border-light mb-3">
   <h4 class="card-header">Server-side component installer</h4>
-    <div class="card-body"> 
+    <div class="card-body">
     <p class="card-text">Install Zowe z/OS components from the <b>convenience build</b> or the <b>SMP/E build</b> depending on your need.</p>
         <div class="row">
           <div class="card-body">
@@ -32,7 +32,7 @@
             <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-circle" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/> <path fill-rule="evenodd" d="M7.646 11.354a.5.5 0 0 1 0-.708L10.293 8 7.646 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0z"/> <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z"/></svg>
             Read installation docs
             </a>
-          </div> 
+          </div>
           </div>
           <div class="card-body">
             <h5 class="card-title">SMP/E build</h5>
@@ -45,7 +45,7 @@
               <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-circle" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/> <path fill-rule="evenodd" d="M7.646 11.354a.5.5 0 0 1 0-.708L10.293 8 7.646 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0z"/> <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z"/></svg>
               Read installation docs
               </a>
-            </div> 
+            </div>
           </div>
        </div>
     </div>
@@ -66,8 +66,20 @@
             <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-circle" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/> <path fill-rule="evenodd" d="M7.646 11.354a.5.5 0 0 1 0-.708L10.293 8 7.646 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0z"/> <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z"/></svg>
             Read installation docs
             </a>
-          </div> 
+          </div>
         </div>
+        <div class="card-body">
+          <h5 class="card-title">Zowe Client SDKs</h5>
+          <p class="card-text">Download the Zowe Software Development Kits (SDKs) for use in development and automation.</p>
+          <p><a class="btn btn-primary" href="{{ site.zowe_node_sdk_download_url }}">Zowe Node Client SDK</a></p>
+          <p><a class="btn btn-primary" href="{{ site.zowe_python_sdk_download_url }}">Zowe Python Client SDK</a></p>
+          <div>
+            <a href="{{ site.zowe_sdk_install_doc_url }}" class="card-link">
+            <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-circle" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/> <path fill-rule="evenodd" d="M7.646 11.354a.5.5 0 0 1 0-.708L10.293 8 7.646 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0z"/> <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z"/></svg>
+            Read installation docs
+            </a>
+          </div>
+       </div>
         <div class="card-body">
           <h5 class="card-title">Zowe Explorer</h5>
           <p class="card-text">Installed directly to VSCode within the GUI</p>
@@ -77,10 +89,10 @@
             <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-circle" fill="currentColor" xmlns="http://www.w3.org/2000/svg"> <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/> <path fill-rule="evenodd" d="M7.646 11.354a.5.5 0 0 1 0-.708L10.293 8 7.646 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0z"/> <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z"/></svg>
             Read installation docs
             </a>
-          </div> 
+          </div>
        </div>
      </div>
-   </div>  
+   </div>
 </div>
 </div>
 {% else %}
@@ -92,7 +104,7 @@
 <p> </p>
 <h1>Previous Releases</h1>
 <p>
-Download previous releases of Zowe by version number. 
+Download previous releases of Zowe by version number.
 </p>
 <p>
 Zowe version 1.0.0 through 1.8.0 are only available as rollup convenience builds. Zowe version 1.9.0 is the beginning of the Active Long-Term Support (LTS) release and it provides an SMP/E build with an FMID of AZWE001. The SMP/E build is the same content as the Zowe 1.9.0 convenience build. Updates in subsequent releases are made available as co-requisite PTFs as well as in convenience builds. Also, starting in 1.9.0, Zowe CLI core and plug-in packages are distributed separately.

--- a/index.md
+++ b/index.md
@@ -40,6 +40,9 @@ Zowe offers modern interfaces to interact with z/OS and allows you to work with 
 <p><b>API Mediation Layer:</b> Provides a gateway that acts as a reverse proxy for z/OS services, together with a catalog of REST APIs and a dynamic discovery capability. Base Zowe provides core services for working with MVS Data Sets, JES, as well as working with z/OSMF REST APIs. The API Mediation Layer also provides a framework for Single Sign On (SSO). </p>
 
 <p><b>Zowe CLI:</b> Provides a command-line interface that lets you interact with the mainframe remotely and use common tools such as Integrated Development Environments (IDEs), shell commands, bash scripts, and build tools for mainframe development. It provides a set of utilities and services for application developers that want to become efficient in supporting and building z/OS applications quickly. The CLI provides a core set of commands for working with data sets, USS, JES, as well as issuing TSO and console commands.</p>
+
+<p><b>Zowe Client Software Development Kits (SDKs)</b> Provides access to a set of programamatic APIs that you can use to build client applications or scripts that interact with z/OS. SDKs are available for Node and Python.</p>
+
 </div>
 
 <div class="videocol">


### PR DESCRIPTION
Adds an overview of the Zowe Client SDKs to the homepage. 

Adds download buttons for the Python and Node SDKs. 

TODO: Add URLs for the hosted SDK packages to enable the buttons. 