### PR TITLE
replace webinar announcement with Zowe survey

### DIFF
--- a/_data/announcements.yml
+++ b/_data/announcements.yml
@@ -1,3 +1,3 @@
 # Announcements
-- announcement: "Zowe Quarterly Update webinar on October 14th, 2020 at 11:30am US Eastern."
-  link: https://www.openmainframeproject.org/event/webinar-zowe-quarterly-update
+- announcement: "The semi-annual Zowe survey closes Friday 1/29.  Don’t miss this chance to make your feedback count:"
+  link: https://www.surveymonkey.com/r/PSGBKRN


### PR DESCRIPTION
Quarterly webinar has passed, the Zowe survey needs advertising

Signed-off-by: Ilya Kreynin <ilya.kreynin@ibm.com>, under the direction of Rose Sakach