### PR TITLE
Provide ways to specify the dates for validity for question of month …

### DIFF
--- a/_data/question_of_month.yml
+++ b/_data/question_of_month.yml
@@ -1,2 +1,10 @@
-# One question of month. If none is provided, nothing is displayed
-link: https://www.surveymonkey.com/r/zowetraining
+# The questions of the month. The from and to shouldn't overlap
+- link: https://www.surveymonkey.com/r/zowev2plans
+  from: 2022-11-01
+  to: 2022-11-30
+- link: https://www.surveymonkey.com/r/zowetraining
+  from: 2022-12-01
+  to: 2022-12-31
+- link: https://www.surveymonkey.com/r/zoweroadmap
+  from: 2023-01-01
+  to: 2023-01-31

--- a/index.md
+++ b/index.md
@@ -114,17 +114,25 @@ redirect_from:
 
 <script src="https://kit.fontawesome.com/f449f80794.js" crossorigin="anonymous"></script>
 
+{% assign currentTime = 'now' | date: '%s' | plus: 0 %}     
 {% if site.data.question_of_month %}  
-  <div id="feedback-closed" class=" feedback-hide" onclick="toggleFeedback();">
-    <span class="question-name">Question for September</span>
+  {% for feedback in site.data.question_of_month %}
+    {% assign fromFeedback = feedback.from | date: '%s' | plus: 0 %}
+    {% assign toFeedback = feedback.to | date: '%s' | plus: 0 %}
+      {% if currentTime > fromFeedback %}
+        {% if toFeedback == 0 or currentTime < toFeedback %}
+<div id="feedback-closed" class=" feedback-hide" onclick="toggleFeedback();">
+  <span class="question-name">Question for September</span>
+</div>
+<div id="feedback">
+  <div class="feedback-header" onclick="toggleFeedback();"><span class="question-name" style="font-size: smaller;">Question for August</span> <div style="float: right; cursor: pointer;"><i class="fa-solid fa-circle-xmark"></i></div></div>
+  <div>
+    <iframe src="{{site.data.question_of_month.link}}" style="height: 357px; width: 270px;"></iframe>
   </div>
-
-  <div id="feedback">
-    <div class="feedback-header" onclick="toggleFeedback();"><span class="question-name" style="font-size: smaller;">Question for August</span> <div style="float: right; cursor: pointer;"><i class="fa-solid fa-circle-xmark"></i></div></div>
-    <div>
-      <iframe src="{{site.data.question_of_month.link}}" style="height: 357px; width: 270px;"></iframe>
-    </div>
-  </div>
+</div>
+        {% endif %}
+      {% endif %}
+  {% endfor %}
 {% endif %}
 
 <div class="announcementsection">
@@ -134,13 +142,19 @@ redirect_from:
   <strong>Zowe version {{ site.data.releases.v1[0].version }} is now available. You can download the installers for this release from the <a href="/download">Download</a> page. To learn what's new in this release, see the <a href="https://docs.zowe.org/v1.28.x/getting-started/release-notes/v1_28_1">Release notes</a>.<br></strong>
   {% if site.data.announcements %}
     {% for announcement in site.data.announcements %}
-    <hr class="w-100" style="margin-top: 0.25rem; margin-bottom: 0.25rem; border-top: 1px solid rgb(0 0 0 / 20%)">
-    <strong>{{ announcement.announcement }}
-      {% if announcement.link %}
-        <a href="{{ announcement.link }}">Learn More</a>
-      {% endif %}
-      <br>
-    </strong>
+      {% assign from = announcement.from | date: '%s' | plus: 0 %}
+      {% assign to = announcement.to | date: '%s' | plus: 0 %}
+        {% if currentTime > from %}
+          {% if to == 0 or currentTime < to %}
+            <hr class="w-100" style="margin-top: 0.25rem; margin-bottom: 0.25rem; border-top: 1px solid rgb(0 0 0 / 20%)">
+            <strong>{{ announcement.announcement }} 
+                   {% if announcement.link %}
+                      <a href="{{ announcement.link }}">Learn More</a>
+                   {% endif %}
+              <br>
+            </strong>  
+          {% endif %}
+        {% endif %}
     {% endfor %}
   {% endif %}
 </div>


### PR DESCRIPTION
…and announcements.

The question of the month was updated to the list of questions. Each question provides validity. This way, we can prepare questions upfront without merging pull requests at specific times. 

This is how one question looks like: 
- link: https://www.surveymonkey.com/r/zowev2plans
  from: 2022-11-01
  to: 2022-11-30

The announcements got the same functionality. If there is no from and to then it behaves the same as it does now. Otherwise if there is no to, the announcement stays, if there is no from then it's visible directly after adding. This is how timed announcement looks like: 

- announcement: "Interested in Zowe current & future plans?  Download the Zowe Roadmap presentation" 
  link: https://github.com/zowe/zowe.github.io/raw/master/assets/roadmap/Zowe%20Roadmap%20CY22Q4.pdf 
  from: 2022-12-19
  to: 2022-12-31

Signed-off-by: Jakub Balhar <jakub@balhar.net>