### PR TITLE
Question of the month styles

### DIFF
--- a/index.md
+++ b/index.md
@@ -73,9 +73,7 @@ redirect_from:
     font-size: 24px;
     margin: 2px;
     font-weight: bold;
-    padding: 6px;
-    padding-left: 12px;
-    padding-right: 12px;
+    padding: 6px 12px;
     cursor: pointer;
     box-shadow: 0px 0px 10px #b2b2b2;
   }
@@ -88,9 +86,7 @@ redirect_from:
     font-size: 24px;
     margin: 2px;
     font-weight: bold;
-    padding-left: 22px;
-    padding-right: 6px;
-    padding-top: 4px;
+    padding: 4px 6px 0 22px;
     cursor: pointer;
   }
 
@@ -98,7 +94,6 @@ redirect_from:
     height: 356px; 
     width: 270px; 
     border: none;
-    border-radius: 0 0 3px 3px;
   }
 
   #intents {

--- a/index.md
+++ b/index.md
@@ -65,19 +65,19 @@ redirect_from:
 
   #feedback-closed {
     position: fixed; 
-    bottom: 10px; 
-    right: 10px;
+    bottom: 24px; 
+    right: 24px; 
     display: none;
-    border-radius: 5px;
-    border: 2px #212529 solid; 
     z-index: 1000;
     background-color: white;
     font-size: 24px;
     margin: 2px;
     font-weight: bold;
-    padding-left: 6px;
-    padding-right: 6px;
+    padding: 6px;
+    padding-left: 12px;
+    padding-right: 12px;
     cursor: pointer;
+    box-shadow: 0px 0px 10px #b2b2b2;
   }
 
   #feedback-closed.feedback-hide, #feedback.feedback-hide {

--- a/index.md
+++ b/index.md
@@ -54,13 +54,12 @@ redirect_from:
 
   #feedback {
     position: fixed; 
-    bottom: 10px; 
-    right: 10px; 
-    border: 2px #212529 solid; 
+    bottom: 24px; 
+    right: 24px; 
     height: 400px;
     background-color: white;
-    border-radius: 5px;
     z-index: 1000;
+    box-shadow: 0px 0px 10px #b2b2b2;
     display: none;
   }
 
@@ -89,9 +88,17 @@ redirect_from:
     font-size: 24px;
     margin: 2px;
     font-weight: bold;
-    padding-left: 6px;
+    padding-left: 22px;
     padding-right: 6px;
+    padding-top: 4px;
     cursor: pointer;
+  }
+
+  .feedback-container {
+    height: 356px; 
+    width: 270px; 
+    border: none;
+    border-radius: 0 0 3px 3px;
   }
 
   #intents {
@@ -125,9 +132,9 @@ redirect_from:
   <span class="question-name">Question for September</span>
 </div>
 <div id="feedback">
-  <div class="feedback-header" onclick="toggleFeedback();"><span class="question-name" style="font-size: smaller;">Question for August</span> <div style="float: right; cursor: pointer;"><i class="fa-solid fa-circle-xmark"></i></div></div>
+  <div class="feedback-header" onclick="toggleFeedback();"><span class="question-name" style="font-size: smaller; color: #008323;">Question for August</span> <div style="float: right; cursor: pointer;"><i class="fa-solid fa-circle-xmark"></i></div></div>
   <div>
-    <iframe src="{{feedback.link}}" style="height: 357px; width: 270px;"></iframe>
+    <iframe class="feedback-container" src="{{feedback.link}}"></iframe>
   </div>
 </div>
         {% endif %}


### PR DESCRIPTION
A simple update of the question of the month box.
I know that there is a work in progress on the zowe.org web page re-design but it will take time to finish, while this question of the month box could look better already, so I checked the design proposals and made it look alike, for a smoother transition to a new design in future
 
<img width="345" alt="Screenshot 2023-01-10 at 18 54 36" src="https://user-images.githubusercontent.com/61471197/211791021-0ba5a43f-0802-4a1c-af8d-77bf94575da2.png">
<img width="337" alt="Screenshot 2023-01-10 at 18 56 29" src="https://user-images.githubusercontent.com/61471197/211791048-767624b5-8be4-4850-bf7f-ee800cdad22c.png">
