### PR TITLE
Provide hashes, signatures and verification instructions for Zowe CLI, CLI Plugins, and Client SDKs

### DIFF
--- a/_includes/legal-script.html
+++ b/_includes/legal-script.html
@@ -4,7 +4,7 @@
     if (params.has('version')) {
         if (params.has('type') && params.get('type') == "cli") {
             document.getElementById('download_button').href =
-                "https://docs.zowe.org/stable/user-guide/cli-installcli.html"
+                "post_download.html?version=" + params.get('version') + "&type=" + params.get('type');
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe CLI ' + params.get('version'), 'zowe-cli-package-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip');
@@ -17,7 +17,7 @@
                 (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip';
         } else if (params.has('type') && params.get('type') == "cli-plugins") {
             document.getElementById('download_button').href =
-                "https://docs.zowe.org/stable/user-guide/cli-installcli.html"
+                "post_download.html?version=" + params.get('version') + "&type=" + params.get('type');
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe CLI Plugins ' + params.get('version'),
                     'zowe-cli-plugins-' +
@@ -87,7 +87,8 @@
             document.getElementById('download_file_message').innerHTML = 'You are downloading zowe-chat-' +
                 params.get('version') + '.tar.gz';
         } else if (params.has('type') && params.get('type') == "python-sdk") {
-            document.getElementById('download_button').href = "https://docs.zowe.org/stable/user-guide/sdks-using.html"
+            document.getElementById('download_button').href = 
+                "post_download.html?version=" + params.get('version') + "&type=" + params.get('type');
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe SMPE ' + params.get('version'), 'zowe-python-sdk-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip');
@@ -99,7 +100,8 @@
             document.getElementById('download_file_message').innerHTML = 'You are downloading zowe-python-sdk-' +
                 (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip';
         } else if (params.has('type') && params.get('type') == "nodejs-sdk") {
-            document.getElementById('download_button').href = "https://docs.zowe.org/stable/user-guide/sdks-using.html"
+            document.getElementById('download_button').href = 
+                "post_download.html?version=" + params.get('version') + "&type=" + params.get('type');
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe SMPE ' + params.get('version'), 'zowe-nodejs-sdk-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip');

--- a/_includes/post-download-script.html
+++ b/_includes/post-download-script.html
@@ -1,28 +1,60 @@
 <!-- Used to write out HTML specifying how to run GPG signing against downloaded binaries -->
 <script>
     params = new URLSearchParams(location.search);
+    
+    filename_prefix = 'zowe'
+    file_ext = 'pax'
+    package_name = 'Zowe Binary'
+
+    if(params.has('type')){
+        switch(params.get('type')){
+            case 'cli':
+                filename_prefix = 'zowe-cli-package';
+                file_ext = 'zip';
+                package_name = 'Zowe CLI Package'
+                break;
+            case 'cli-plugins':
+                filename_prefix = 'zowe-cli-plugins';
+                file_ext = 'zip';
+                package_name = 'Zowe CLI Plugins Package'
+                break;
+            case 'nodejs-sdk':
+                filename_prefix = 'zowe-nodejs-sdk';
+                file_ext = 'zip';
+                package_name = 'Zowe Node.js Client SDK'
+                break;
+            case 'python-sdk':
+                filename_prefix = 'zowe-python-sdk';
+                file_ext = 'zip';
+                package_name = 'Zowe Python Client SDK'
+                break;
+        }
+    }
+
     if (params.has('version')) {
         document.getElementById('download_link').href = "legal.html?version=" + params.get('version');
+
+        document.getElementById('page_title').innerText = 'Thank you for downloading the ' + package_name;
+        document.getElementById('verify_drop').innerText = 'Verify Hash and Signature of ' + package_name;
         document.getElementById('hash_download').href = "https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
-            params.get('version') + "/zowe-" + params.get('version') + ".pax.sha512";
+            params.get('version') + "/" + filename_prefix + "-" + params.get('version') + "." + file_ext + ".sha512";
         document.getElementById('hash_download').onclick = function () {
-            ga && ga('send', 'event', 'download', 'Zowe Binary Hash ' + params.get('version'), 'zowe-' + params.get(
-                'version') + '.pax.sha512');
+            ga && ga('send', 'event', 'download', package_name + ' Hash ' + params.get('version'), filename_prefix + '-' + 
+                params.get('version') + '.' + file_ext + '.sha512');
         }
-        document.getElementById('hash_download').innerHTML = 'zowe-' + params.get('version') + '.pax.sha512';
-        document.getElementById('hash_code').innerHTML = '(gpg --print-md SHA512 zowe-' + params.get('version') +
-            '.pax &gt; zowe-' + params.get('version') + '.pax.sha512.my) && diff zowe-' + params.get('version') +
-            '.pax.sha512.my zowe-' + params.get('version') + '.pax.sha512 && echo matched || echo "not match"';
-        document.getElementById('hash_my').innerHTML = 'zowe-' + params.get('version') + '.pax.sha512.my';
-        document.getElementById('signature_download').href =
-            "https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') + "/zowe-" + params
-            .get(
-                'version') + ".pax.asc";
+        document.getElementById('hash_download').innerHTML = filename_prefix + "-" + params.get('version') + "." + file_ext + ".sha512"; 
+        document.getElementById('hash_code').innerHTML = '(gpg --print-md SHA512 ' + filename_prefix + "-" + params.get('version') +
+            '.' + file_ext + ' &gt; ' + filename_prefix + "-" + params.get('version') + '.' + file_ext + '.sha512.my) && diff ' + filename_prefix +
+            "-" + params.get('version') + '.' + file_ext + '.sha512.my ' + filename_prefix + "-" + params.get('version') + '.' + file_ext + 
+            '.sha512 && echo matched || echo "not match"';
+        document.getElementById('hash_my').innerHTML = filename_prefix + "-" + params.get('version') + '.' + file_ext + '.sha512.my';
+        document.getElementById('signature_download').href = "https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
+            "/" + filename_prefix + "-" + params.get('version') + "." + file_ext + ".asc";
         document.getElementById('signature_download').onclick = function () {
-            ga && ga('send', 'event', 'download', 'Zowe Binary Signature ' + params.get('version'), 'zowe-' + params
-                .get('version') + '.pax.asc');
+            ga && ga('send', 'event', 'download', package_name + ' Signature ' + params.get('version'), filename_prefix + "-" + params.get('version') + 
+            '.' + file_ext + '.asc');
         }
-        document.getElementById('signature_download').innerHTML = 'zowe-' + params.get('version') + '.pax.asc';
+        document.getElementById('signature_download').innerHTML = filename_prefix + "-" + params.get('version') + '.' + file_ext + '.asc';
         xhttp = new XMLHttpRequest();
         xhttp.onreadystatechange = function () {
             if (this.readyState == 4 && this.status == 200) {
@@ -41,7 +73,8 @@
         xhttp.open("GET", "https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
             "/code-signing-key-info.json", true);
         xhttp.send();
-        document.getElementById('gpg_command').innerHTML = 'gpg --verify zowe-' + params.get('version') +
-            '.pax.asc zowe-' + params.get('version') + '.pax';
+        document.getElementById('gpg_command').innerHTML = 'gpg --verify ' + filename_prefix + "-" + params.get('version') +
+            '.' + file_ext + '.asc ' + filename_prefix + "-" + params.get('version') + '.' + file_ext; 
     }
+    
 </script>

--- a/post_download.md
+++ b/post_download.md
@@ -1,15 +1,15 @@
 ---
 title: "Download"
-extraHeaders: google-analytics-downloads-header.html 
+extraHeaders: google-analytics-downloads-header.html
 extraJs: post-download-script.html
 ---
 <section class="whitebackground">
-  <h1 class="title">Thank you for downloading the Zowe binary</h1>
+  <h1 class="title" id="page_title">Thank you for downloading the Zowe binary</h1>
   <p>If you had an issue or your download did not start, please <strong>
   	<a id="download_link" href="legal.html">click here</a>
 	</strong> to try again.</p><br>
   <details>
-    <summary>Verify Hash and Signature of Zowe Binary</summary>
+    <summary id='verify_drop'>Verify Hash and Signature of Zowe Binary</summary>
     <p>These commands are tested on both <strong>Mac OS X v10.13.6</strong> and <strong>Ubuntu v17.11.</strong></p>
 	<br>
     <h2><b>Step 1</b> - Verify Hash Code</h2>


### PR DESCRIPTION
This PR modifies legal-script.html, post-download-script.html, and post_download.md to show the same hash/signature page that has only been shown for the PAX file download, extending it for the CLI, CLI plugins, and Node.js and Python client SDKs. This PR uses a switch-case statement based on a type parameter passed in the URL from the legal-script.html page to alter text and links in post_download.md.

I am not sure if this is the most sensible way for this to be done. Feel free to suggest/make any changes.

Part of https://github.com/zowe/zowe.github.io/issues/830