### PR TITLE
Revert logo to SVG

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -46,7 +46,7 @@
       <img src="/assets/img/lf-projects.svg" alt="Linux Foundation Logo" class="img-top" >
       <div>
         <div class="zowe-img-middle">
-          <img class="zowe-img-middle-inner" src="/assets/img/transparent-Zowe-logo2.gif" alt="Zowe Logo">
+          <img class="zowe-img-middle-inner" src="/assets/img/zowe-logo.svg" alt="Zowe Logo">
         </div>
       </div>
       <button class="navbar-toggler burgerbtn" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"


### PR DESCRIPTION
As a fix for https://github.com/zowe/zowe.github.io/issues/876 I'm not familiar with how to make an animated SVG that serves the same purpose as the animated GIF, but the SVG does have higher quality and better performance (https://github.com/zowe/zowe.github.io/issues/875) so perhaps reverting to it is the easiest solution.