### PR TITLE
Updates to CLI Vnext items

### DIFF
--- a/_data/vnext_changes.yml
+++ b/_data/vnext_changes.yml
@@ -39,13 +39,12 @@
 
     **Breaking changes**
 
+    - Introduce new format for error messages to improve clarity
     - Remove V1 profile support
-    - Change authentication order of preference
     - Remove deprecated items - [CLI](https://github.com/zowe/zowe-cli/issues/1694) and [Imperative](https://github.com/zowe/imperative/issues/970)
 
     **Important updates**
 
-    - Support multiple API ML Gateway connections within a single config file. 
     - Provide a Jenkinsfile template to replace shared library (github.com/zowe/zowe-cli-version-controller)
 
 - name: Explorer for Intellij


### PR DESCRIPTION
Removes:
- Change authentication order of preference
- Support multiple API ML Gateway connections within a single config file. 

Adds:
- Introduce new format for error messages to improve clarity

From the CLI standpoint, we already have the ability to specify which APIML instance to target using the --base-profile option. We are still planning to add support for APIML service instance IDs, however that may not be complete before the release of V3.