### PR TITLE
Add prerelease info for Zowe CLI and Explorer (VS Code)

### DIFF
--- a/_data/vnext_changes.yml
+++ b/_data/vnext_changes.yml
@@ -43,9 +43,9 @@
     - Remove V1 profile support
     - Remove deprecated items - [CLI](https://github.com/zowe/zowe-cli/issues/1694) and [Imperative](https://github.com/zowe/imperative/issues/970)
 
-    **Prerelease availability**
+    **Pre-release availability**
 
-    - V3 prerelease versions are available via [npm](https://www.npmjs.com/package/@zowe/cli) under the 'next' tag.
+    - V3 pre-release versions are available via [npm](https://www.npmjs.com/package/@zowe/cli) under the 'next' tag.
 
 - name: Explorer for Intellij
   homepage_link: /#zowe-intellij-plugin-intro
@@ -77,9 +77,9 @@
     - Store persistent settings in local storage
     - Compare files in MVS view, the USS view and across the two views
 
-    **Prerelease availability**
+    **Pre-release availability**
 
-    - V3 prerelease versions are available via [GitHub releases](https://github.com/zowe/vscode-extension-for-zowe/releases) or via the [Open VSX Registry](https://open-vsx.org/extension/Zowe/vscode-extension-for-zowe).
+    - V3 pre-release versions are available via [GitHub releases](https://github.com/zowe/vscode-extension-for-zowe/releases) or via the [Open VSX Registry](https://open-vsx.org/extension/Zowe/vscode-extension-for-zowe).
 
 - name: Installation and Packaging 
   homepage_link: 

--- a/_data/vnext_changes.yml
+++ b/_data/vnext_changes.yml
@@ -43,9 +43,9 @@
     - Remove V1 profile support
     - Remove deprecated items - [CLI](https://github.com/zowe/zowe-cli/issues/1694) and [Imperative](https://github.com/zowe/imperative/issues/970)
 
-    **Important updates**
+    **Prerelease availability**
 
-    - Provide a Jenkinsfile template to replace shared library (github.com/zowe/zowe-cli-version-controller)
+    - V3 prerelease versions are available via [npm](https://www.npmjs.com/package/@zowe/cli) under the 'next' tag.
 
 - name: Explorer for Intellij
   homepage_link: /#zowe-intellij-plugin-intro
@@ -76,6 +76,10 @@
 
     - Store persistent settings in local storage
     - Compare files in MVS view, the USS view and across the two views
+
+    **Prerelease availability**
+
+    - V3 prerelease versions are available via [GitHub releases](https://github.com/zowe/vscode-extension-for-zowe/releases) or via the [Open VSX Registry](https://open-vsx.org/extension/Zowe/vscode-extension-for-zowe).
 
 - name: Installation and Packaging 
   homepage_link: 


### PR DESCRIPTION
Added pre-release information for Zowe CLI and Explorer.
Removed potentially confusing note on the jenkinsfile template.