### PR TITLE
Update Zowe Explorer GitHub repository links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -63,10 +63,10 @@ zowe_cli_ftp_plugin_url: https://github.com/zowe/zowe-cli-ftp-plugin
 zowe_cli_ims_plugin_url: https://github.com/zowe/zowe-cli-ims-plugin
 zowe_cli_mq_plugin_url: https://github.com/zowe/zowe-cli-mq-plugin
 zowe_explorer_doc_url: https://docs.zowe.org/stable/user-guide/ze-install.html#installing-zowe-explorer
-zowe_explorer_github_url: https://github.com/zowe/vscode-extension-for-zowe
+zowe_explorer_github_url: https://github.com/zowe/zowe-explorer-vscode
 zowe_explorer_slack_url: https://openmainframeproject.slack.com/archives/CUVE37Z5F
-zowe_explorer_next_github_url: https://github.com/zowe/vscode-extension-for-zowe/releases
-zowe_explorer_next_doc_url: https://github.com/zowe/vscode-extension-for-zowe/tree/next/docs/Early%20Access%20-%20Using%20Global%20Profile%20Configuration.md
+zowe_explorer_next_github_url: https://github.com/zowe/zowe-explorer-vscode/releases
+zowe_explorer_next_doc_url: https://github.com/zowe/zowe-explorer-vscode/tree/next/docs/Early%20Access%20-%20Using%20Global%20Profile%20Configuration.md
 zowe_cics_explorer_next_github_url: https://github.com/zowe/vscode-extension-for-cics/releases
 zowe_sdk_doc_url: https://docs.zowe.org/stable/getting-started/overview.html#zowe-client-software-development-kits-sdks
 zowe_sdk_github_url: https://github.com/zowe/zowe-cli

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -25,7 +25,7 @@
   dedication: Core
 - name: Zowe Explorer
   description: A Visual Studio Code extension that modernizes the way developers and system administrators interact with z/OS mainframes. Zowe Explorer lets you interact with data sets, USS files, and jobs that are stored on z/OS. The extension complements your Zowe CLI experience and lets you use authentication services like API Mediation Layer.
-  github_url: https://github.com/zowe/vscode-extension-for-zowe
+  github_url: https://github.com/zowe/zowe-explorer-vscode
   slack_url: https://openmainframeproject.slack.com/archives/CUVE37Z5F
   doc_url: https://docs.zowe.org/stable/user-guide/ze-install.html#installing-zowe-explorer
   img_url: assets/img/zowe-explorer-image.webp

--- a/_data/v2/vnext_changes.yml
+++ b/_data/v2/vnext_changes.yml
@@ -81,9 +81,9 @@
   image: /assets/img/zowe-explorer-image.webp
   description: |
 
-    - Changes to settings keys - automated migration of settings when user opens Zowe Explorer v2: (includes documentation) ([#PR 1450](https://github.com/zowe/vscode-extension-for-zowe/pull/1450))
-    - [Using Global Profile Configuration](https://github.com/zowe/vscode-extension-for-zowe/blob/next/docs/Early%20Access%20-%20Using%20Global%20Profile%20Configuration.md)
-    - [Changes Affecting Extenders](https://github.com/zowe/vscode-extension-for-zowe/blob/next/docs/Early%20Access%20-%20Changes%20Affecting%20Extenders.md)
+    - Changes to settings keys - automated migration of settings when user opens Zowe Explorer v2: (includes documentation) ([#PR 1450](https://github.com/zowe/zowe-explorer-vscode/pull/1450))
+    - [Using Global Profile Configuration](https://github.com/zowe/zowe-explorer-vscode/blob/next/docs/Early%20Access%20-%20Using%20Global%20Profile%20Configuration.md)
+    - [Changes Affecting Extenders](https://github.com/zowe/zowe-explorer-vscode/blob/next/docs/Early%20Access%20-%20Changes%20Affecting%20Extenders.md)
 
 - name: Systems
   homepage_link: 

--- a/_data/v2/vnext_faq.yml
+++ b/_data/v2/vnext_faq.yml
@@ -121,7 +121,7 @@ general:
       
       The recommended approach for editing the config file is to launch it in VS Code from Zowe Explorer and make modifications there. The designated user responsible for creating and maintaining the config (we recommend a team lead or Administrator) will be able to leverage the built-in “intellisense” when editing the file. *Note: **Team Config fundamentally changes the paradigm on profile creation & management.** Prior to Team Config, **all users** were required to understand, create, test, trouble-shoot, and manage their own profiles. Team Config was designed to scale all of these tasks back, remove the burden from individual users and centralize it. Once the config is distributed most users should not need to make any significant edits.*
 
-      Join the discussion on this topic here: [https://github.com/zowe/vscode-extension-for-zowe/discussions/1535](https://github.com/zowe/vscode-extension-for-zowe/discussions/1535)
+      Join the discussion on this topic here: [https://github.com/zowe/zowe-explorer-vscode/discussions/1535](https://github.com/zowe/zowe-explorer-vscode/discussions/1535)
 
 
 

--- a/_data/vnext_changes.yml
+++ b/_data/vnext_changes.yml
@@ -69,7 +69,7 @@
     **Breaking changes**
 
     - Remove V1 profile support
-    - Remove deprecated items - [Explorer for VSCode](https://github.com/zowe/vscode-extension-for-zowe/issues/2238)
+    - Remove deprecated items - [Explorer for VSCode](https://github.com/zowe/zowe-explorer-vscode/issues/2238)
     - Change profile creation menus
     - Store extension settings in the local storage
 
@@ -80,7 +80,7 @@
 
     **Pre-release availability**
 
-    - V3 pre-release versions are available via [GitHub releases](https://github.com/zowe/vscode-extension-for-zowe/releases) or via the [Open VSX Registry](https://open-vsx.org/extension/Zowe/vscode-extension-for-zowe).
+    - V3 pre-release versions are available via [GitHub releases](https://github.com/zowe/zowe-explorer-vscode/releases) or via the [Open VSX Registry](https://open-vsx.org/extension/Zowe/vscode-extension-for-zowe).
 
 - name: Installation and Packaging 
   homepage_link: 


### PR DESCRIPTION
Updates links to the Zowe Explorer repository to the new address
zowe/zowe-explorer-vscode#1237