### PR TITLE
Use the new OMP Calendar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ slack_url: https://slack.openmainframeproject.org
 mailing_list_user_url: https://lists.openmainframeproject.org/g/zowe-user
 youtube_zowe_url: https://www.youtube.com/playlist?list=PL8REpLGaY9QE_9d57tw3KQdwSVLKuTpUZ
 conformance_page_url: https://www.openmainframeproject.org/projects/zowe/conformance
-omp_calendar_url: https://lists.openmainframeproject.org/g/zowe-dev/calendar
+omp_calendar_url: https://zoom-lfx.platform.linuxfoundation.org/meetings/zowe
 zos_download_url: legal.html?version=
 containerization_download_url: legal.html?type=containerization&version=
 cli_download_url:  legal.html?type=cli&version=

--- a/contribute.md
+++ b/contribute.md
@@ -68,7 +68,7 @@
     <h2 style="margin-bottom: 1.5rem; margin-top: 2%">Join a squad call</h2>
     <p>Zowe is an open source project - this means that anyone can contribute to any part of it, and that includes you! The best ways to first get involved are <a href="{{ site.create_zowe_issue_url }}">opening issues on GitHub</a>, saying hi on Slack, or joining the weekly calls of one of the squads listed below.</p>
     <p>Zowe’s most frequent and dedicated contributors work in teams called “squads”. If you have specific questions or are excited about a particular part of Zowe, connect with the relevant squad using the table below! Occasionally, some of the meetings might be changed, cancelled or rescheduled. Stay up to date on meetings in the <a href="{{ site.omp_calendar_url }}">Zowe meeting calendar</a> or the Slack channels.</p>
-    <iframe class="mt-4" src="https://calendar.google.com/calendar/embed?src=c55ndlc8frlvhau31r13fggmvfg4qmeu%40import.calendar.google.com&ctz=America%2FNew_York" style="border: 0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
+    <iframe class="mt-4" src="https://zoom-lfx.platform.linuxfoundation.org/meetings/zowe" style="border: 0" width="100%" height="600" frameborder="0" scrolling="no"></iframe>
   </div>
 </section>
 


### PR DESCRIPTION
The visual of the integrated calendar. 

![Screenshot 2024-05-27 at 20 25 39](https://github.com/zowe/zowe.github.io/assets/1757251/7860d68f-a65b-4344-9c33-d573729d76e2)
