### PR TITLE
Update docs site versions to fix redirects

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -38,7 +38,7 @@ v2:
     node_sdk_version: 2.16.0
     python_sdk_version: 2.16.0
     release_date: 2024-05-23
-    documentation: v2_16_x
+    documentation: v2.16.x
     release_notes: v2_16_0
   - version: 2.15.0
     zos_version: 2.15.0
@@ -53,7 +53,7 @@ v2:
     node_sdk_version: 2.15.0
     python_sdk_version: 2.15.0
     release_date: 2024-03-08
-    documentation: v2_15_x
+    documentation: v2.15.x
     release_notes: v2_15_0
   - version: 2.14.0
     zos_version: 2.14.0
@@ -67,7 +67,7 @@ v2:
     node_sdk_version: 2.14.0
     python_sdk_version: 2.14.0
     release_date: 2024-01-26
-    documentation: v2_14_x
+    documentation: v2.14.x
     release_notes: v2_14_0
   - version: 2.13.0
     zos_version: 2.13.0
@@ -81,7 +81,7 @@ v2:
     node_sdk_version: 2.13.0
     python_sdk_version: 2.13.0
     release_date: 2023-12-14
-    documentation: v2_13_x
+    documentation: versions
     release_notes: v2_13_0
   - version: 2.12.0
     zos_version: 2.12.0
@@ -95,7 +95,7 @@ v2:
     node_sdk_version: 2.12.0
     python_sdk_version: 2.12.0
     release_date: 2023-10-24
-    documentation: v2_12_x
+    documentation: versions
     release_notes: v2_12_0
   - version: 2.11.0
     zos_version: 2.11.0
@@ -109,7 +109,7 @@ v2:
     node_sdk_version: 2.11.0
     python_sdk_version: 2.11.0
     release_date: 2023-09-12
-    documentation: v2_11_x
+    documentation: versions
     release_notes: v2_11_0
   - version: 2.10.0
     zos_version: 2.10.0
@@ -123,7 +123,7 @@ v2:
     node_sdk_version: 2.10.0
     python_sdk_version: 2.10.0
     release_date: 2023-07-27
-    documentation: v2_10_x
+    documentation: versions
     release_notes: v2_10_0
   - version: 2.9.0
     zos_version: 2.9.0
@@ -137,7 +137,7 @@ v2:
     node_sdk_version: 2.9.0
     python_sdk_version: 2.9.0
     release_date: 2023-06-13
-    documentation: v2_9_x
+    documentation: versions
     release_notes: v2_9_0
   - version: 2.8.0
     zos_version: 2.8.0
@@ -151,7 +151,7 @@ v2:
     node_sdk_version: 2.8.0
     python_sdk_version: 2.8.0
     release_date: 2023-04-26
-    documentation: v2_8_x
+    documentation: versions
     release_notes: v2_8_0
   - version: 2.7.0
     zos_version: 2.7.0
@@ -165,7 +165,7 @@ v2:
     node_sdk_version: 2.7.0
     python_sdk_version: 2.7.0
     release_date: 2023-03-15
-    documentation: v2.7.x
+    documentation: versions
     release_notes: v2_7_0
   - version: 2.6.1
     zos_version: 2.6.1
@@ -179,7 +179,7 @@ v2:
     node_sdk_version: 2.6.1
     python_sdk_version: 2.6.1
     release_date: 2023-02-10
-    documentation: v2.6.x
+    documentation: versions
     release_notes: v2_6_1
   - version: 2.6.0
     zos_version: 2.6.0
@@ -193,7 +193,7 @@ v2:
     node_sdk_version: 2.6.0
     python_sdk_version: 2.6.0
     release_date: 2023-01-27
-    documentation: v2.6.x
+    documentation: versions
     release_notes: v2_6_0
   - version: 2.5.0
     zos_version: 2.5.0
@@ -206,7 +206,7 @@ v2:
     node_sdk_version: 2.5.0
     python_sdk_version: 2.5.0
     release_date: 2022-12-12
-    documentation: v2.5.x
+    documentation: versions
     release_notes: v2_5_0
   - version: 2.4.0
     zos_version: 2.4.0
@@ -219,7 +219,7 @@ v2:
     node_sdk_version: 2.4.0
     python_sdk_version: 2.4.0
     release_date: 2022-10-19
-    documentation: v2.4.x
+    documentation: versions
     release_notes: v2_4_0
   - version: 2.3.1
     zos_version: 2.3.1
@@ -232,7 +232,7 @@ v2:
     node_sdk_version: 2.3.0
     python_sdk_version: 2.3.0
     release_date: 2022-09-29
-    documentation: v2.3.x
+    documentation: versions
     release_notes: v2_3_1
   - version: 2.3.0
     zos_version: 2.3.0
@@ -245,7 +245,7 @@ v2:
     node_sdk_version: 2.3.0
     python_sdk_version: 2.3.0
     release_date: 2022-09-21
-    documentation: v2.3.x
+    documentation: versions
     release_notes: v2_3_0
   - version: 2.2.0
     zos_version: 2.2.0
@@ -258,7 +258,7 @@ v2:
     node_sdk_version: 2.2.0
     python_sdk_version: 2.2.0
     release_date: 2022-07-25
-    documentation: v2.2.x
+    documentation: versions
     release_notes: v2_2_0
   - version: 2.1.0
     zos_version: 2.1.0
@@ -271,7 +271,7 @@ v2:
     node_sdk_version: 2.1.0
     python_sdk_version: 2.1.0
     release_date: 2022-06-13
-    documentation: v2.1.x
+    documentation: versions
     release_notes: v2_1_0
   - version: 2.0.0
     zos_version: 2.0.0
@@ -284,7 +284,7 @@ v2:
     node_sdk_version: 2.0.0
     python_sdk_version: 2.0.0
     release_date: 2022-04-27
-    documentation: v2.0.x
+    documentation: versions
     release_notes: v2_0_0
 v1:
   - version: 1.28.7
@@ -394,7 +394,7 @@ v1:
     node_sdk_version: 1.27.3
     python_sdk_version: 1.27.3
     release_date: 2022-04-05
-    documentation: v1.27.x
+    documentation: versions
     release_notes: v1_27_3
   - version: 1.27.2
     zos_version: 1.27.1
@@ -406,7 +406,7 @@ v1:
     node_sdk_version: 1.27.2
     python_sdk_version: 1.27.2
     release_date: 2022-02-17
-    documentation: v1.27.x
+    documentation: versions
     release_notes: v1_27_2
   - version: 1.27.1
     zos_version: 1.27.1
@@ -418,7 +418,7 @@ v1:
     node_sdk_version: 1.27.1
     python_sdk_version: 1.27.1
     release_date: 2022-02-08
-    documentation: v1.27.x
+    documentation: versions
     release_notes: v1_27_1
   - version: 1.27.0
     zos_version: 1.27.0
@@ -430,7 +430,7 @@ v1:
     node_sdk_version: 1.27.0
     python_sdk_version: 1.27.0
     release_date: 2022-01-24
-    documentation: v1.27.x
+    documentation: versions
     release_notes: v1_27
   - version: 1.26.0
     zos_version: 1.26.0
@@ -442,7 +442,7 @@ v1:
     node_sdk_version: 1.26.0
     python_sdk_version: 1.26.0
     release_date: 2021-12-13
-    documentation: v1.26.x
+    documentation: versions
     release_notes: v1_26
   - version: 1.25.0
     zos_version: 1.25.0
@@ -454,7 +454,7 @@ v1:
     node_sdk_version: 1.25.0
     python_sdk_version: 1.25.0
     release_date: 2021-10-25
-    documentation: v1.25.x
+    documentation: versions
     release_notes: v1_25
   - version: 1.24.0
     zos_version: 1.24.0
@@ -466,7 +466,7 @@ v1:
     node_sdk_version: 1.24.0
     python_sdk_version: 1.24.0
     release_date: 2021-09-15
-    documentation: v1.24.x
+    documentation: versions
     release_notes: v1_24
   - version: 1.23.0
     zos_version: 1.23.0
@@ -478,7 +478,7 @@ v1:
     node_sdk_version: 1.23.0
     python_sdk_version: 1.23.0
     release_date: 2021-07-26
-    documentation: v1.23.x
+    documentation: versions
     release_notes: v1_23
   - version: 1.22.0
     zos_version: 1.22.0
@@ -490,7 +490,7 @@ v1:
     node_sdk_version: 1.22.0
     python_sdk_version: 1.22.0
     release_date: 2021-06-14
-    documentation: v1.22.x
+    documentation: versions
   - version: 1.21.0
     zos_version: 1.21.0
     smpe_version: 1.21.0


### PR DESCRIPTION
Update docs site links in the releases YAML file to do the following:

- Point to versions page for versions <2.14.0 and <1.28.0, which are the oldest available versions on the live docs site
- Replace `_` with `.` in newer verisons, as the docs site uses `.`s in the version URLs 