### PR TITLE
Hide release list under details section

### DIFF
--- a/download.md
+++ b/download.md
@@ -837,6 +837,8 @@
 
     <h1 id="all-v3-releases">All Zowe V3.x Releases</h1>
     <p>Download releases of Zowe V3.x by version number. The future release dates are tentative and may change.</p>
+    <details>
+      <summary>Click to show V3.x Releases</summary>
     <div style="overflow-x: auto">
       <table class="table table-hover table-sm">
     {% for release in site.data.releases.future.v3 %}
@@ -892,9 +894,12 @@
     </div>
     {% endif %}
     {% endfor %}
+    </details>
 
   <h1 id="all-v2-releases">All Zowe V2.x Releases</h1>
   <p>Download releases of Zowe V2.x by version number. The future release dates are tentative and may change.</p>
+  <details>
+    <summary>Click to show V2.x Releases</summary>
   <div style="overflow-x: auto">
     <table class="table table-hover table-sm">
   {% for release in site.data.releases.future.v2 %}
@@ -950,9 +955,12 @@
   </div>
   {% endif %}
   {% endfor %}
+  </details>
 
 <h1 id="all-v1-releases">All Zowe V1.x Releases</h1>
-<p>Download releases of Zowe V1.x by version number. The future release dates are tentative and may change.</p>
+<p>Download releases of Zowe V1.x by version number. V1.x is no longer updated or supported.</p>
+<details>
+  <summary>Click to show V1.x Releases</summary>
 <p>
   Zowe version 1.0.0 through 1.8.0 are only available as rollup convenience builds. Zowe version 1.9.0 is the
   beginning of the Active Long-Term Support (LTS) release and it provides an SMP/E build with an FMID of AZWE001. The
@@ -1016,6 +1024,7 @@
 <p class="text-muted">All builds prior to Zowe v1.0.0 are no longer available.</p>
 {% endif %}
 {% endfor %}
+</details>
 </section>
 
 <section class="bluebackground">


### PR DESCRIPTION
The list of releases for each version of zowe is very long.
https://www.zowe.org/download if you scroll to the bottom, to try and find our release timeline info for example, it's quite a long scroll.

But, the list of releases probably isnt something people look at much. We don't really want to promote people downloading old versions if they could use the latest.

So, if we can hide them under a collapsible section that you click to expand, then all the info can still be there, but not visible until requested.

It looks like this:
<img width="1185" alt="image" src="https://github.com/user-attachments/assets/998a32aa-6fdf-461c-9ac5-721b33fa754e">
