### PR TITLE
Save last downloaded URL & display it in post download page

### DIFF
--- a/_includes/legal-script.html
+++ b/_includes/legal-script.html
@@ -13,7 +13,7 @@
                 `post_download.html?version=${pkgVers}&type=${params.get('type')}`;
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', componentName, artifact);
-                window.open(`https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/${pkgVers}/${artifact}`,
+                windowOpenAndSaveURL(`https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/${pkgVers}/${artifact}`,
                     '_blank');
             }
         }
@@ -23,7 +23,7 @@
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe CLI ' + params.get('version'), 'zowe-cli-package-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
                     (params.get('preview') ? 'next' : params.get('version')) + '/zowe-cli-package-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip',
                     '_blank');
@@ -37,7 +37,7 @@
                 ga && ga('send', 'event', 'download', 'Zowe CLI Plugins ' + params.get('version'),
                     'zowe-cli-plugins-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
                     (params.get('preview') ? 'next' : params.get('version')) + '/zowe-cli-plugins-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip',
                     '_blank');
@@ -51,7 +51,7 @@
                 ga && ga('send', 'event', 'download', 'Zowe SMPE ' + params.get('version'), 'zowe-smpe-package-' +
                     params.get(
                         'version') + '.zip');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
                     '/zowe-smpe-package-' + params.get('version') + '.zip', '_blank');
             }
             document.getElementById('download_file_message').innerHTML = 'You are downloading zowe-smpe-package-' +
@@ -65,7 +65,7 @@
                 ga && ga('send', 'event', 'download', 'Zowe Containerization ' + params.get('version'),
                     'zowe-containerization-' +
                     params.get('version') + '.zip');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
                     '/zowe-containerization-' + params.get('version') + '.zip', '_blank');
             }
             document.getElementById('download_file_message').innerHTML = 'You are downloading zowe-containerization-' +
@@ -83,7 +83,7 @@
                 ga && ga('send', 'event', 'download', 'Zowe PSWI ' + params.get('version'), 'zowe-PSWI-' +
                     params.get(
                         'version') + '.pax.Z');
-                window.open(pswiUrl, '_blank');
+                windowOpenAndSaveURL(pswiUrl, '_blank');
             }
             document.getElementById('download_file_message').innerHTML = 'You are downloading zowe-PSWI-' +
                 params
@@ -96,7 +96,7 @@
                 ga && ga('send', 'event', 'download', 'Zowe Chat ' + params.get('version'),
                     'zowe-chat-' +
                     params.get('version') + '.tar.gz');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/chat/" + params.get('version') +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/chat/" + params.get('version') +
                     '/zowe-chat-' + 'tech-preview-1.tar.gz', '_blank'); // + params.get('version') + '.tar.gz', '_blank');
             }
             document.getElementById('download_file_message').innerHTML = 'You are downloading zowe-chat-' +
@@ -107,7 +107,7 @@
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe SMPE ' + params.get('version'), 'zowe-python-sdk-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
                     (params.get('preview') ? 'next' : params.get('version')) + '/zowe-python-sdk-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip',
                     '_blank');
@@ -120,7 +120,7 @@
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe SMPE ' + params.get('version'), 'zowe-nodejs-sdk-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" +
                     (params.get('preview') ? 'next' : params.get('version')) + '/zowe-nodejs-sdk-' +
                     (params.get('preview') ? 'next-' + params.get('preview') : params.get('version')) + '.zip',
                     '_blank');
@@ -133,7 +133,7 @@
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe CLI Active Development ' + params.get('version'),
                     'zowe-cli-package-' + params.get('package') + '.zip');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
                     '-active-development-cli/zowe-cli-package-' + params.get('package') + '.zip', '_blank');
             }
             document.getElementById('download_file_message').innerHTML = 'You are downloading zowe-cli-package-' +
@@ -171,7 +171,7 @@
                 ga && ga('send', 'event', 'download',
                     params.get('type') + ' ' + params.get('version'), // e.g. zen-windows 1.0.0, zen-deb 1.1.0
                     zenFile);
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/zen/" + zenRtPath, '_blank');
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/zen/" + zenRtPath, '_blank');
             }
             document.getElementById('download_file_message').innerHTML =
                 `You are downloading the Zowe Server Install Wizard for ${zenDistro} version ${params.get('version')}`;
@@ -181,7 +181,7 @@
             document.getElementById('download_button').onclick = function () {
                 ga && ga('send', 'event', 'download', 'Zowe Binary ' + params.get('version'), 'zowe-' + params.get(
                     'version') + '.pax');
-                window.open("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
+                windowOpenAndSaveURL("https://zowe.jfrog.io/zowe/list/libs-release-local/org/zowe/" + params.get('version') +
                     '/zowe-' + params.get('version') + '.pax', '_blank');
             }
             document.getElementById('download_file_message').innerHTML = 'You are downloading zowe-' + params.get(
@@ -189,5 +189,9 @@
                 '.pax';
         }
 
+    }
+    function windowOpenAndSaveURL(url) {
+        localStorage.setItem('zowe-last-download-url', url);
+        window.open(url, '_blank');
     }
 </script>

--- a/post_download.md
+++ b/post_download.md
@@ -7,8 +7,17 @@ extraJs: [common.html, post-download-script.html]
     <h1 class="title" id="page_title">Thank you for downloading the Zowe binary</h1>
     <p>
         If you had an issue or your download did not start, please <strong><a id="download_link" href="/download">click
-                here</a></strong> to try again.
+                here</a></strong> to try again or copy the following URL to your browser: 
+        <span id="download_url_display"></span>
     </p>
+    <script>
+        // Retrieve the download URL from localStorage
+        const lastDownloadURL = localStorage.getItem('zowe-last-download-url') || 'No download started yet.';
+        const urlDisplay = document.getElementById('download_url_display');
+        if (urlDisplay) {
+            urlDisplay.textContent = lastDownloadURL; // Display the URL
+        }
+    </script>
     <details>
         <summary id='verify_drop'><b>How to verify binaries with digital signatures</b></summary>
         <br />

--- a/post_download_legacy.md
+++ b/post_download_legacy.md
@@ -7,8 +7,17 @@ extraJs: post-download-script-legacy.html
     <h1 class="title" id="page_title">Thank you for downloading the Zowe binary</h1>
     <p>
         If you had an issue or your download did not start, please <strong><a id="download_link" href="legal.html">click
-                here</a></strong> to try again.
+                here</a></strong> to try again or copy the following URL to your browser: 
+        <span id="download_url_display"></span>
     </p>
+    <script>
+        // Retrieve the download URL from localStorage
+        const lastDownloadURL = localStorage.getItem('zowe-last-download-url') || 'No download started yet.';
+        const urlDisplay = document.getElementById('download_url_display');
+        if (urlDisplay) {
+            urlDisplay.textContent = lastDownloadURL; // Display the URL
+        }
+    </script>
     <details>
         <summary id='verify_drop'><b>Verify Hash and Signature of Zowe Binary</b></summary>
         <p>These commands are tested on both <strong>Mac OS X v10.13.6</strong> and <strong>Ubuntu v17.11.</strong></p>


### PR DESCRIPTION
Simple use of localStorage to store last downloaded URL and then add it to post download page. This doesnt break Legal because it is after the Agree/Disagree step

This adds support to V3, V2, V1, and every major downloadable thing I see in the Downloads section

<img width="706" alt="image" src="https://github.com/user-attachments/assets/4c55c628-dbb0-4ef2-94bc-34318da05dbb">

<img width="770" alt="image" src="https://github.com/user-attachments/assets/4adbfc60-2862-4c33-b73b-0605808437fa">

<img width="761" alt="image" src="https://github.com/user-attachments/assets/00da6c12-1ce2-45d4-917a-5521a848fbb3">
