### PR TITLE
updating Documentation links in Zowe V1 table

### DIFF
--- a/download.md
+++ b/download.md
@@ -799,9 +799,9 @@
       <td></td>
       {% endif %}
       {% if release.documentation == 'versions' %}
-      <td><a href="https://docs.zowe.org/versions/">Documentation</a></td>
+      <td><a href="https://67c89aa5af702da5881fc564--zowe-docs-master.netlify.app/v1.28.x/getting-started/overview/">Documentation</a></td>
       {% else %}
-      <td><a href="https://docs.zowe.org/{{release.documentation}}/getting-started/overview">Documentation</a></td>
+      <td><a href="https://67c89aa5af702da5881fc564--zowe-docs-master.netlify.app/v1.28.x/getting-started/overview/">Documentation</a></td>
       {% endif %}
     </tr>
 


### PR DESCRIPTION
Per what was agreed during the March 6 TSC meeting, this PR updates the links for Documentation in the Zowe V1 table.