### PR TITLE
update cli versions to 2.18.2

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -49,11 +49,11 @@ v2:
     smpe_sysmod: PTF
     smpe_numbers: UO90074 UO90075
     containerization_version: 2.18.1
-    cli_version: 2.18.1
-    cli_plugins_version: 2.18.1
+    cli_version: 2.18.2
+    cli_plugins_version: 2.18.2
     explorer_version: 2.18.1
     node_sdk_version: 2.18.1
-    python_sdk_version: 2.18.1
+    python_sdk_version: 2.18.2
     release_date: 2025-03-27
     documentation: stable
     release_notes: v2_18_1


### PR DESCRIPTION
Updates CLI version to 2.18.2, associated with the server side 2.18.1 release. The 2.18.1 CLI artifacts are lost on the downloads page this way, but the alternative is to duplicate the server side release under the v2 table. 