### PR TITLE
Added PSWI download button to All Releases table

### DIFF
--- a/download.md
+++ b/download.md
@@ -22,6 +22,22 @@
     border-bottom: inherit;
   }
 
+  .details-container {
+    padding-bottom: 18px;
+  }
+
+  .details-container .card-header {
+    border-bottom: none;
+  }
+
+  table.all-releases-zebra tr:nth-child(even) {
+    background-color: #ffffff;
+  }
+
+  table.all-releases-zebra tr:nth-child(odd) {
+    background-color: #f8f9fa;
+  }
+
 </style>
 
 <section class="whitebackground">
@@ -620,10 +636,10 @@
 
     <h1 id="all-v3-releases">All Zowe V3.x Releases</h1>
     <p>Download releases of Zowe V3.x by version number. The future release dates are tentative and may change.</p>
-    <details>
-      <summary>Click to show V3.x Releases</summary>
+    <details class="details-container">
+      <summary class="card-header">Click to show V3.x Releases</summary>
     <div style="overflow-x: auto">
-      <table class="table table-hover table-sm">
+      <table class="table table-hover table-sm all-releases-zebra">
     {% for release in site.data.releases.future.v3 %}
       <tr>
         <td>Zowe {{release.version}} ({{release.release_date}})</td>
@@ -687,10 +703,10 @@
 
   <h1 id="all-v2-releases">All Zowe V2.x Releases</h1>
   <p>Download releases of Zowe V2.x by version number. The future release dates are tentative and may change.</p>
-  <details>
-    <summary>Click to show V2.x Releases</summary>
+  <details class="details-container">
+    <summary class="card-header">Click to show V2.x Releases</summary>
   <div style="overflow-x: auto">
-    <table class="table table-hover table-sm">
+    <table class="table table-hover table-sm all-releases-zebra">
   {% for release in site.data.releases.future.v2 %}
     <tr>
       <td>Zowe {{release.version}} ({{release.release_date}})</td>
@@ -754,8 +770,8 @@
 
 <h1 id="all-v1-releases">All Zowe V1.x Releases</h1>
 <p>Download releases of Zowe V1.x by version number. V1.x is no longer updated or supported.</p>
-<details>
-  <summary>Click to show V1.x Releases</summary>
+<details class="details-container">
+  <summary class="card-header">Click to show V1.x Releases</summary>
 <p>
   Zowe version 1.0.0 through 1.8.0 are only available as rollup convenience builds. Zowe version 1.9.0 is the
   beginning of the Active Long-Term Support (LTS) release and it provides an SMP/E build with an FMID of AZWE001. The
@@ -765,7 +781,7 @@
 </p>
 
 <div style="overflow-x: auto">
-  <table class="table table-hover table-sm">
+  <table class="table table-hover table-sm all-releases-zebra">
 {% for release in site.data.releases.future.v1 %}
   <tr>
     <td>Zowe {{release.version}} ({{release.release_date}})</td>

--- a/download.md
+++ b/download.md
@@ -30,12 +30,16 @@
     border-bottom: none;
   }
 
-  table.all-releases-zebra tr:nth-child(even) {
+  table.all-releases-zebra tr:nth-child(odd) {
     background-color: #ffffff;
   }
 
-  table.all-releases-zebra tr:nth-child(odd) {
+  table.all-releases-zebra tr:nth-child(even) {
     background-color: #f8f9fa;
+  }
+
+  table.all-releases-zebra tr:last-child {
+    border-bottom: 1px solid #dee2e6
   }
 
 </style>

--- a/download.md
+++ b/download.md
@@ -632,6 +632,7 @@
         <td></td>
         <td></td>
         <td></td>
+        <td></td>
       </tr>
     {% endfor %}
     {% for release in site.data.releases.v3 %}
@@ -648,6 +649,11 @@
           {% elsif release.smpe_version and release.smpe_sysmod %}
           <td><a href="{{site.smpe_download_url}}{{release.smpe_version}}">SMP/E {{release.smpe_sysmod}}
               {{release.smpe_numbers}}</a></td>
+          {% else %}
+          <td></td>
+          {% endif %}
+          {% if release.zos_version %}
+          <td><a href="{{site.pswi_download_uri}}{{release.zos_version}}">PSWI {{release.zos_version}}</a></td>
           {% else %}
           <td></td>
           {% endif %}
@@ -693,6 +699,7 @@
       <td></td>
       <td></td>
       <td></td>
+      <td></td>
     </tr>
   {% endfor %}
   {% for release in site.data.releases.v2 %}
@@ -709,6 +716,11 @@
         {% elsif release.smpe_version and release.smpe_sysmod %}
         <td><a href="{{site.smpe_download_url}}{{release.smpe_version}}">SMP/E {{release.smpe_sysmod}}
             {{release.smpe_numbers}}</a></td>
+        {% else %}
+        <td></td>
+        {% endif %}
+        {% if release.zos_version %}
+        <td><a href="{{site.pswi_download_uri}}{{release.zos_version}}">PSWI {{release.zos_version}}</a></td>
         {% else %}
         <td></td>
         {% endif %}


### PR DESCRIPTION
Added PSWI download button to All Releases table for versions 2 and 3
Also added some minimal styles 

![Screenshot 2025-06-16 at 15 47 50](https://github.com/user-attachments/assets/d58c9dd3-363d-474c-b0ea-8bc0b198e153)

Addresses https://github.com/zowe/zowe.github.io/issues/969