### PR TITLE
Prepare v2.18.3 Release

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -3,7 +3,7 @@
 future:
   v3:
     - version: 3.4.0
-      release_date: 2025-11-17
+      release_date: 2025-12-01
   v2:
     - version: 2.18.4
       release_date: 2026-08-31

--- a/vNext.md
+++ b/vNext.md
@@ -49,11 +49,11 @@
 
   <h4>3.4.0</h4>
   <ul>
-    <li>Code Freeze: October 20, 2025</li>
-    <li>RC Build: October 21, 2025</li>
-    <li>Testing: October 21, 2025 - November 17, 2025</li>
-    <li>GA: November 17, 2025</li>
-    <li>System Demo: November 25, 2025</li>
+    <li>Code Freeze: November 3, 2025</li>
+    <li>RC Build: November 4, 2025</li>
+    <li>Testing: November 4, 2025 - December 1, 2025</li>
+    <li>GA: December 1, 2025</li>
+    <li>System Demo: December 9, 2025</li>
   </ul>
 
   <h4>3.5.0</h4>
@@ -89,8 +89,8 @@
   <ul>
     <li>Code Freeze: September 19, 2025</li>
     <li>RC Build: September 23, 2025</li>
-    <li>Testing: September 23, 2025 - October 6, 2025</li>
-    <li>GA: October 7, 2025</li>
+    <li>Testing: September 23, 2025 - October 31, 2025</li>
+    <li>GA: October 31, 2025</li>
   </ul>
 
   <h4>2.18.4</h4>


### PR DESCRIPTION
Adds 2.18.3, and updates the date for 2.18.4. 

Also updates the planned released date for 3.4.0 to match the 2 week delay in code freeze.


 Date [pulled from here](https://github.com/zowe/community/blob/master/Project%20Management/Schedule/Zowe%20PI%20%26%20Sprint%20Cadence.md#2184)