### PR TITLE
update release for 2.18.4

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -94,11 +94,11 @@ v2:
     smpe_sysmod: PTF
     smpe_numbers: UO90078 UO90079
     containerization_version: 2.18.3
-    cli_version: 2.18.3
-    cli_plugins_version: 2.18.3
-    explorer_version: 2.18.3
-    node_sdk_version: 2.18.3
-    python_sdk_version: 2.18.3
+    cli_version: 2.18.4
+    cli_plugins_version: 2.18.4
+    explorer_version: 2.18.4
+    node_sdk_version: 2.18.4
+    python_sdk_version: 2.18.4
     release_date: 2025-10-31
     documentation: stable
     release_notes: v2_18_3


### PR DESCRIPTION
client side only release; the active release now shows 2.18.3 for server side and 2.18.4 for client side ( we've "lost" the client 2.18.3 release until #962 is addressed)