### PR TITLE
Change jerryjvl/jekyll-build-action to actions/jekyll-build-pages

### DIFF
--- a/.github/workflows/update_static_html.yml
+++ b/.github/workflows/update_static_html.yml
@@ -42,7 +42,7 @@ jobs:
       uses: zowe-actions/shared-actions/prepare-workflow@main
 
     - name: Build site
-      uses: jerryjvl/jekyll-build-action@v1
+      uses: actions/jekyll-build-pages@v1
 
     - name: Publish Release to Artifactory
       uses: zowe-actions/shared-actions/publish@main


### PR DESCRIPTION
I created this because #986 was closed.

This PR is for change [jerryjvl/jekyll-build-action](https://github.com/jerryjvl/jekyll-build-action) to [actions/jekyll-build-pages](https://github.com/actions/jekyll-build-pages) in [update_static_html.yml](https://github.com/zowe/zowe.github.io/blob/master/.github/workflows/update_static_html.yml).

I apologize for the inconvenience.