### PR TITLE
removing tech preview section

### DIFF
--- a/download.md
+++ b/download.md
@@ -582,38 +582,7 @@
       </div>
     </div>
   </div>
-
-
     <p> </p>
-    <h2 id="zowe-technical-preview">Zowe Technical Preview</h2>
-    <p>
-      Test the latest Zowe features and provide feedback. Technical previews are <b>for testing only</b> and not ready
-      for production.</p>
-    <div class="card-deck">
-      <div class="card bg-light border-light mb-3">
-        <h4 class="card-header" id="zowe-client-sdks-download">Zowe Client SDKs</h4>
-         <div class="card-body">
-          <p class="card-text">Download the Zowe Software Development Kits (SDKs) for use in development and
-          automation.</p>
-          <h5 class="card-title">Direct download</h5>
-          <p><a class="btn btn-primary"
-                href="{{ site.zowe_python_sdk_download_url }}{{ site.data.releases.v2[0].python_sdk_version }}">Zowe Python Client SDK</a></p>
-          <div>
-              <a href="{{ site.zowe_sdk_install_doc_url }}"
-                class="card-link">
-                <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-circle" fill="currentColor"
-                  xmlns="http://www.w3.org/2000/svg">
-                  <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z" />
-                  <path fill-rule="evenodd"
-                    d="M7.646 11.354a.5.5 0 0 1 0-.708L10.293 8 7.646 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0z" />
-                  <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z" /></svg>
-                Browse SDK docs
-            </a>
-          </div>    
-        </div>   
-     </div>    
-    </div>
-
     <h1 id="all-v3-releases">All Zowe V3.x Releases</h1>
     <p>Download releases of Zowe V3.x by version number. The future release dates are tentative and may change.</p>
     <details class="details-container">

--- a/download.md
+++ b/download.md
@@ -72,15 +72,6 @@
               <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z" /></svg>
             Latest V2 Release
           </a>
-          <a href="#zowe-technical-preview" class="card-link">
-            <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-circle" fill="currentColor"
-              xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z" />
-              <path fill-rule="evenodd"
-                d="M7.646 11.354a.5.5 0 0 1 0-.708L10.293 8 7.646 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708 0z" />
-              <path fill-rule="evenodd" d="M4.5 8a.5.5 0 0 1 .5-.5h5a.5.5 0 0 1 0 1H5a.5.5 0 0 1-.5-.5z" /></svg>
-            Technical Preview
-          </a>
           <a href="#all-v3-releases" class="card-link">
             <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-circle" fill="currentColor"
               xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Removing the technical preview section as the Zowe Python Client SDK is no longer under technical preview.