### PR TITLE
Zowe 3.6.0 clients

### DIFF
--- a/_data/announcements.yml
+++ b/_data/announcements.yml
@@ -1,6 +1,6 @@
 # Announcements
 # Links need to be shared within announcement in the HTML form e.g. <a href='url'>text visible for user</a>
-- announcement: "Zowe 3.4.1 and 2.18.4 are now available with critical fixes for z/OSMF compatibility."
+- announcement: "Zowe 3.6.0 is now available for Zowe CLI and Zowe Explorer."
   priority: high
-  until: 2026-02-10
+  until: 2026-09-20
 - announcement: "Stay informed, join our <a href='https://lists.openmainframeproject.org/g/zowe-user'>Zowe User mailing list</a> today"

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -15,12 +15,12 @@ v3:
     smpe_sysmod: PTF
     smpe_numbers: UO03576 UO03577
     containerization_version: 3.5.0
-    cli_version: 3.5.0
-    cli_plugins_version: 3.5.0
+    cli_version: 3.6.0
+    cli_plugins_version: 3.6.0
     intellij_explorer_version: 3.5.0
     explorer_version: 3.5.0
-    node_sdk_version: 3.5.0
-    python_sdk_version: 3.5.0
+    node_sdk_version: 3.6.0
+    python_sdk_version: 3.6.0
     release_date: 2026-05-21
     documentation: stable
     release_notes: v3_5_0

--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -18,7 +18,7 @@ v3:
     cli_version: 3.6.0
     cli_plugins_version: 3.6.0
     intellij_explorer_version: 3.5.0
-    explorer_version: 3.5.0
+    explorer_version: 3.6.0
     node_sdk_version: 3.6.0
     python_sdk_version: 3.6.0
     release_date: 2026-05-21


### PR DESCRIPTION
Zowe clients 3.5 temporarily "disappears" due to our releases data structure tightly coupling server and client releases

Added a special announcement for Zowe 3.6 clients, and kept original release date for 3.5 servers.